### PR TITLE
Fix issue with pixfmt compatibility

### DIFF
--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -394,7 +394,7 @@ int UsbCam::init_mjpeg_decoder(int image_width, int image_height)
   avcodec_context_->codec_type = AVMEDIA_TYPE_VIDEO;
 #endif
 
-  avframe_camera_size_ = avpicture_get_size(AV_PIX_FMT_YUV422P, image_width, image_height);
+  avframe_camera_size_ = avpicture_get_size(AV_PIX_FMT_YUV420P, image_width, image_height);
   avframe_rgb_size_ = avpicture_get_size(AV_PIX_FMT_RGB24, image_width, image_height);
 
   /* open it */


### PR DESCRIPTION
Change to a deprecated format to work with the buffer size of usb_cam.