### PR TITLE
Suppress incompatibility warnings

### DIFF
--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -436,6 +436,11 @@ void UsbCam::mjpeg2rgb(char *MJPEG, int len, char *RGB, int NumPixels)
     return;
   }
 
+  if (avcodec_context_->pix_fmt == AV_PIX_FMT_YUVJ420P)
+  {
+    avcodec_context_->pix_fmt = AV_PIX_FMT_YUV420P;
+  }
+
   int xsize = avcodec_context_->width;
   int ysize = avcodec_context_->height;
   int pic_size = avpicture_get_size(avcodec_context_->pix_fmt, xsize, ysize);

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -374,6 +374,8 @@ int UsbCam::init_mjpeg_decoder(int image_width, int image_height)
     return 0;
   }
 
+  av_log_set_level(AV_LOG_ERROR);
+
   avcodec_context_ = avcodec_alloc_context3(avcodec_);
 #if LIBAVCODEC_VERSION_MAJOR < 55
   avframe_camera_ = avcodec_alloc_frame();


### PR DESCRIPTION
Supress two warnings:
- [x] Override returned `pix_fmt` to suppress deprecation warning
- [x] Set avcodec log level to error to suppress colorspace conversion acceleration warning (not available on aarch64)