### PR TITLE
CRS-782: Add ROS parameter for tuning MJPEG video streaming

### DIFF
--- a/include/usb_cam/usb_cam.h
+++ b/include/usb_cam/usb_cam.h
@@ -76,7 +76,7 @@ class UsbCam {
 
   // start camera
   void start(const std::string& dev, io_method io, pixel_format pf,
-		    int image_width, int image_height, int framerate);
+		    int bits_per_pixel, int image_width, int image_height, int framerate);
   // shutdown camera
   void shutdown(void);
 
@@ -94,6 +94,8 @@ class UsbCam {
 
   static io_method io_method_from_string(const std::string& str);
   static pixel_format pixel_format_from_string(const std::string& str);
+  // Get the actual pixel format for MJPEG video from bits per pixels
+  static AVPixelFormat get_avcodec_pixel_format(int bits_per_pixel);
 
   void stop_capturing(void);
   void start_capturing(void);
@@ -117,7 +119,7 @@ class UsbCam {
   };
 
 
-  int init_mjpeg_decoder(int image_width, int image_height);
+  int init_mjpeg_decoder(int bits_per_pixel, int image_width, int image_height);
   void mjpeg2rgb(char *MJPEG, int len, char *RGB, int NumPixels);
   void process_image(const void * src, int len, camera_image_t *dest);
   int read_frame();

--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -56,11 +56,10 @@ public:
 
   // parameters
   std::string video_device_name_, io_method_name_, pixel_format_name_, camera_name_, camera_info_url_;
-  //std::string start_service_name_, start_service_name_;
   std::string serial_number_;
   bool streaming_status_;
-  int image_width_, image_height_, framerate_, exposure_, brightness_, contrast_, saturation_, sharpness_, focus_,
-      white_balance_, gain_, power_line_frequency_, gamma_, backlight_compensation_;
+  int image_width_, image_height_, framerate_, bits_per_pixel_, exposure_, brightness_, contrast_, saturation_,
+      sharpness_, focus_, white_balance_, gain_, power_line_frequency_, gamma_, backlight_compensation_;
   bool autofocus_, autoexposure_, auto_white_balance_;
   boost::shared_ptr<camera_info_manager::CameraInfoManager> cinfo_;
 
@@ -104,6 +103,7 @@ public:
     node_.param("framerate", framerate_, 30);
     // possible values: yuyv, uyvy, mjpeg, yuvmono10, rgb24
     node_.param("pixel_format", pixel_format_name_, std::string("mjpeg"));
+    node_.param("bits_per_pixel", bits_per_pixel_, 12);
     // enable/disable autofocus
     node_.param("autofocus", autofocus_, false);
     node_.param("focus", focus_, -1); //0-255, -1 "leave alone"
@@ -166,8 +166,9 @@ public:
     }
 
 
-    ROS_INFO("Starting '%s' (%s) at %dx%d via %s (%s) at %i FPS", camera_name_.c_str(), video_device_name_.c_str(),
-        image_width_, image_height_, io_method_name_.c_str(), pixel_format_name_.c_str(), framerate_);
+    ROS_INFO("Starting '%s' (%s) at %dx%d via %s (%s %d bpp) at %i FPS", camera_name_.c_str(),
+             video_device_name_.c_str(), image_width_, image_height_, io_method_name_.c_str(),
+             pixel_format_name_.c_str(), bits_per_pixel_, framerate_);
 
     // set the IO method
     UsbCam::io_method io_method = UsbCam::io_method_from_string(io_method_name_);
@@ -188,7 +189,7 @@ public:
     }
 
     // start the camera
-    cam_.start(video_device_name_.c_str(), io_method, pixel_format, image_width_,
+    cam_.start(video_device_name_.c_str(), io_method, pixel_format, bits_per_pixel_, image_width_,
 		     image_height_, framerate_);
 
     // set camera parameters


### PR DESCRIPTION
MJPEG video frame format can have multiple pixel formats and we need to provide a way to allow the user to set up the appropriate one for establishing image buffers in the right way. The most common pixel formats supported by ffmpeg codec are YUV420P, a 12 bits-per-pixel encoding, and YUV422P, a 16 bits-per-pixel encoding. We are adding a new integer ROS parameter to control the selection of the both most used encodings for MJPEG: 'bits_per_pixel'. Only two values are valid
as today: 12 and 16; the former is the default.