### PR TITLE
SFS-2543: Add backlight_compensation parameter to usb parameters

### DIFF
--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -60,7 +60,7 @@ public:
   std::string serial_number_;
   bool streaming_status_;
   int image_width_, image_height_, framerate_, exposure_, brightness_, contrast_, saturation_, sharpness_, focus_,
-      white_balance_, gain_, power_line_frequency_, gamma_;
+      white_balance_, gain_, power_line_frequency_, gamma_, backlight_compensation_;
   bool autofocus_, autoexposure_, auto_white_balance_;
   boost::shared_ptr<camera_info_manager::CameraInfoManager> cinfo_;
 
@@ -116,6 +116,7 @@ public:
     node_.param("white_balance", white_balance_, 4000);
     node_.param("power_line_frequency", power_line_frequency_, 1);
     node_.param("gamma", gamma_, 50);
+    node_.param("backlight_compensation", backlight_compensation_, 1);
 
     // load the camera info
     node_.param("camera_frame_id", img_.header.frame_id, std::string("head_camera"));
@@ -224,6 +225,11 @@ public:
     if (gamma_ >= 0)
     {
       cam_.set_v4l_parameter("gamma", gamma_);
+    }
+
+    if (backlight_compensation_ >= 0)
+    {
+      cam_.set_v4l_parameter("backlight_compensation", backlight_compensation_);
     }
 
     // check auto white balance


### PR DESCRIPTION
Add extra parameters to usb camera parameters.

This parameter helps to reduce over exposure and it is necessary to set the
backlight_compensation parameter to get the expected results.
