### PR TITLE
SFS-3375: Fix usb_cam loading serial number using MJPEG pixel format

### DIFF
--- a/include/usb_cam/device_utils.h
+++ b/include/usb_cam/device_utils.h
@@ -27,3 +27,25 @@ str_map get_serial_dev_info();
  * @param pixel_format  the selected pixel format.
  */
 void clear_unsupported_devices(str_map& maps, std::string pixel_format);
+
+/**
+ * @brief A function that create a map that associate the pixel format name
+ * used by usb_cam and V4L.
+ * This function save a map <std::string, std::string> where the usb_cam pixel
+ * format name is the key of the map.
+ * 
+ * @return map of <std::string, std::string> where the usb_cam pixel format
+ * name is the key.
+ */
+str_map get_pixel_format_map();
+
+/**
+ * @brief A function that get a pixel format name that works for V4L.
+ * 
+ * @param maps reference of map of <std::string, std::string> with the pixel
+ * format name used by usb_cam and V4L.
+ * @param pixel_format  the pixel format name used at usb_cam.
+ * 
+ * @return std::string  the pixel format name used at V4L.
+ */
+std::string get_pixel_format_v4l(str_map& maps, std::string pixel_format);

--- a/src/device_utils.cpp
+++ b/src/device_utils.cpp
@@ -51,9 +51,30 @@ str_map get_serial_dev_info()
   return devices;
 }
 
+std::string get_pixel_format_v4l(str_map& maps, std::string pixel_format)
+{
+  std::string result = pixel_format;
+  str_map::iterator it = maps.find(pixel_format);
+  if (it != maps.end())
+  {
+    result = it->second;
+  }
+  return result;
+}
+
+str_map get_pixel_format_map()
+{
+  str_map pixel_format_map;
+  // V4L uses MJPG and usb_cam uses MJPEG
+  pixel_format_map["MJPEG"] = "MJPG";
+  return pixel_format_map;
+}
+
 void clear_unsupported_devices(str_map& maps, std::string pixel_format)
 {
-  std::string upper_str = boost::to_upper_copy<std::string>(pixel_format);
+  str_map pixel_format_map = get_pixel_format_map();
+  std::string upper_str = get_pixel_format_v4l(pixel_format_map,
+    boost::to_upper_copy<std::string>(pixel_format));
 
   auto it = maps.cbegin();
   while (it != maps.cend())


### PR DESCRIPTION
Since [usb_cam](http://wiki.ros.org/usb_cam) and [V4L](https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/pixfmt-reserved.html) use different names for MJPEG/MJPG pixel format, the driver fails during the setup. Bellow the V4L output:

```
flippy@compute.sb.canopy.dev:~$ v4l2-ctl --device=/dev/video2 --list-formats-ext
ioctl: VIDIOC_ENUM_FMT
	Index       : 0
	Type        : Video Capture
	Pixel Format: 'MJPG' (compressed)
	Name        : Motion-JPEG
		Size: Discrete 1920x1080
			Interval: Discrete 0.033s (30.000 fps)
		Size: Discrete 1280x720
			Interval: Discrete 0.033s (30.000 fps)
		Size: Discrete 640x480
			Interval: Discrete 0.033s (30.000 fps)
		Size: Discrete 320x240
			Interval: Discrete 0.033s (30.000 fps)
		Size: Discrete 1920x1080
			Interval: Discrete 0.033s (30.000 fps)

	Index       : 1
	Type        : Video Capture
	Pixel Format: 'YUYV'
	Name        : YUYV 4:2:2
		Size: Discrete 640x480
			Interval: Discrete 0.033s (30.000 fps)
		Size: Discrete 320x240
			Interval: Discrete 0.033s (30.000 fps)
		Size: Discrete 640x480
			Interval: Discrete 0.033s (30.000 fps)
```



