### PR TITLE
FSIT-3352: Shutdown stopped node

### DIFF
--- a/include/usb_cam/usb_cam.h
+++ b/include/usb_cam/usb_cam.h
@@ -81,7 +81,7 @@ class UsbCam {
   void shutdown(void);
 
   // grabs a new image from the camera
-  void grab_image(sensor_msgs::Image* image);
+  bool grab_image(sensor_msgs::Image* image);
 
   // enables/disable auto focus
   void set_auto_focus(int value);
@@ -130,7 +130,7 @@ class UsbCam {
   void init_device(int image_width, int image_height, int framerate);
   void close_device(void);
   void open_device(void);
-  void grab_image();
+  bool grab_image();
   bool is_capturing_;
 
 

--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -337,8 +337,7 @@ public:
   bool take_and_send_image()
   {
     // grab the image
-    cam_.grab_image(&img_);
-
+    if(!cam_.grab_image(&img_)) ros::shutdown();
     // grab the camera info
     sensor_msgs::CameraInfoPtr ci(new sensor_msgs::CameraInfo(cinfo_->getCameraInfo()));
     ci->header.frame_id = img_.header.frame_id;


### PR DESCRIPTION
Instead of stopping the program, properly shutdown the node when error occurs. This is useful for automatically re-spawning the node.