### PR TITLE
FSIT-3393: Add auto reset exposure setting

### DIFF
--- a/launch/usb_cam-test.launch
+++ b/launch/usb_cam-test.launch
@@ -7,6 +7,7 @@
     <param name="pixel_format" value="yuyv" />
     <param name="camera_frame_id" value="usb_cam" />
     <param name="io_method" value="mmap"/>
+    <param name="auto_reset_exposure_period" value="60"/>
   </node>
   <node name="image_view" pkg="image_view" type="image_view" respawn="false" output="screen">
     <remap from="image" to="/usb_cam/image_raw"/>


### PR DESCRIPTION
This commit adds a feature to auto-reset the camera exposure setting every 1 minute when it is enabled.

Merge with:
- https://github.com/MisoRobotics/chippy/pull/1682