### PR TITLE
FSIT-3680: Fix autobin auto reset exposure setting

### DIFF
--- a/include/usb_cam/usb_cam.h
+++ b/include/usb_cam/usb_cam.h
@@ -101,6 +101,9 @@ class UsbCam {
   void start_capturing(void);
   bool is_capturing();
 
+  bool is_changing_config();
+  void is_changing_config(bool is_changing);
+
  private:
   typedef struct
   {
@@ -132,6 +135,7 @@ class UsbCam {
   void open_device(void);
   bool grab_image();
   bool is_capturing_;
+  bool is_changing_config_;
 
 
   std::string camera_dev_;

--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -356,7 +356,7 @@ public:
 
   void resetExposureSettings()
   {
-    cam_.stop_capturing();
+    cam_.is_changing_config(true);
     cam_.set_v4l_parameter(
       "exposure_auto",
       AUTO_EXPOSURE_APERTURE_PRIORITY_MODE
@@ -366,7 +366,7 @@ public:
     );
     cam_.set_v4l_parameter("exposure_auto", AUTO_EXPOSURE_MANUAL_MODE);
     cam_.set_v4l_parameter("exposure_absolute", exposure_);
-    cam_.start_capturing();
+    cam_.is_changing_config(false);
   }
 
   void checkAutoResetExposure(const ros::TimerEvent&)
@@ -382,7 +382,7 @@ public:
     ros::Rate loop_rate(this->framerate_);
     while (node_.ok())
     {
-      if (cam_.is_capturing()) {
+      if (cam_.is_capturing() && !cam_.is_changing_config()) {
         if (!take_and_send_image()) ROS_WARN("USB camera did not respond in time.");
       }
       ros::spinOnce();

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -356,7 +356,8 @@ void rgb242rgb(char *YUV, char *RGB, int NumPixels)
 UsbCam::UsbCam()
   : io_(IO_METHOD_MMAP), fd_(-1), buffers_(NULL), n_buffers_(0), avframe_camera_(NULL),
     avframe_rgb_(NULL), avcodec_(NULL), avoptions_(NULL), avcodec_context_(NULL),
-    avframe_camera_size_(0), avframe_rgb_size_(0), video_sws_(NULL), image_(NULL), is_capturing_(false) {
+    avframe_camera_size_(0), avframe_rgb_size_(0), video_sws_(NULL), image_(NULL),
+    is_capturing_(false), is_changing_config_(false) {
 }
 UsbCam::~UsbCam()
 {
@@ -595,6 +596,14 @@ int UsbCam::read_frame()
 
 bool UsbCam::is_capturing() {
   return is_capturing_;
+}
+
+bool UsbCam::is_changing_config() {
+  return is_changing_config_;
+}
+
+void UsbCam::is_changing_config(bool is_changing) {
+  is_changing_config_ = is_changing;
 }
 
 void UsbCam::stop_capturing(void)


### PR DESCRIPTION
# The issue
After restarting the computer, some cameras were loading overexposed images.

# The fix

- Stop capturing images from the V4L2 driver, set exposure settings, and start capturing images again have a different result of setting exposure while the node is capturing the images.

- The change is to setting the exposure without stopping the capture and not publishing the content to rostopic.

## Note
Checking ` v4l2-ctl -d /dev/video0 --all` output while the auto reset exposure routine is running the exposure settings were applied correctly. 