### PR TITLE
SFS-14610: Publish ROS Diagnostics Frequency Status tick in main loop

### DIFF
--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -348,8 +348,6 @@ public:
 
     // publish the image
     image_pub_.publish(img_, *ci);
-    diag_freq_camera_info_->tick();
-    diag_freq_image_raw_->tick();
 
     return true;
   }
@@ -387,6 +385,8 @@ public:
       }
       ros::spinOnce();
       heartbeat_.update();
+      diag_freq_camera_info_->tick();
+      diag_freq_image_raw_->tick();
       loop_rate.sleep();
 
     }


### PR DESCRIPTION
Updated the code to publish the ros diagnostics frequency status tick in the main loop.

Without this the tick for the frequency status were seemed to be not getting published periodically,
and the tick was getting registered sporadically. 