### PR TITLE
F3-2048: Make periodic auto exposure reset optional

### DIFF
--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -326,16 +326,11 @@ public:
     ROS_ASSERT(diag_freq_camera_info_);
 
     enable_auto_reset_exposure_ = true;
-    if (auto_reset_exposure_period_ > 0) {
-      auto_reset_exposure_timer_ = node_.createTimer(
-          ros::Duration(auto_reset_exposure_period_),
-          boost::bind(&UsbCamNode::checkAutoResetExposure, this, _1));
-    } else {
-      // Reset exposure once just in case it wasn't applied
-      std::this_thread::sleep_for(
-          std::chrono::seconds{WAIT_CHANGING_AUTO_EXPOSURE_SEC});
-      resetExposureSettings();
-    }
+    auto_reset_exposure_timer_ = node_.createTimer(
+      ros::Duration(auto_reset_exposure_period_),
+      boost::bind(&UsbCamNode::checkAutoResetExposure, this, _1),
+      auto_reset_exposure_period_ <= 0
+    );
   }
 
   virtual ~UsbCamNode()

--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -62,6 +62,9 @@ const int WAIT_CHANGING_AUTO_EXPOSURE_SEC = 2;
 //! \brief Timer period in seconds between calls to reset camera exposure setting
 const double AUTO_RESET_EXPOSURE_PERIOD = 60.0;
 
+//! \brief Timer period in seconds between calls to reset camera exposure setting
+const double ONE_SHOT_RESET_EXPOSURE_WAIT = 5.0;
+
 class UsbCamNode
 {
   misocpp::DiagnosticHeartbeat heartbeat_;
@@ -326,10 +329,12 @@ public:
     ROS_ASSERT(diag_freq_camera_info_);
 
     enable_auto_reset_exposure_ = true;
+    bool timer_oneshot = auto_reset_exposure_period_ <= 0;
+    double timer_period = timer_oneshot ? ONE_SHOT_RESET_EXPOSURE_WAIT : auto_reset_exposure_period_
     auto_reset_exposure_timer_ = node_.createTimer(
-      ros::Duration(auto_reset_exposure_period_),
+      ros::Duration(timer_period),
       boost::bind(&UsbCamNode::checkAutoResetExposure, this, _1),
-      auto_reset_exposure_period_ <= 0
+      timer_oneshot
     );
   }
 


### PR DESCRIPTION
Make periodic auto exposure reset optional since it stops streaming images when resetting and causing the framerate to drop significantly. With this PR, periodic auto exposure reset is disabled when the period is set to be less or equal than 0. From testing, it's seen that when exposure is not applied correctly during launch, it got applied correctly the first time the reset exposure function is called, so we are keeping that function to be called once even when the periodic auto exposure reset is disabled.