### PR TITLE
F3-5443: Add pause before setting the exposure level

### DIFF
--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -362,24 +362,33 @@ public:
 
   void resetExposureSettings()
   {
-    cam_.is_changing_config(true);
+    // Set auto exposure to on
     cam_.set_v4l_parameter(
       "auto_exposure",
       AUTO_EXPOSURE_APERTURE_PRIORITY_MODE
     );
+
     std::this_thread::sleep_for(
       std::chrono::seconds{ WAIT_CHANGING_AUTO_EXPOSURE_SEC }
     );
+
+    // Set exposure time to off
     cam_.set_v4l_parameter("auto_exposure", AUTO_EXPOSURE_MANUAL_MODE);
+
+    std::this_thread::sleep_for(
+      std::chrono::seconds{ WAIT_CHANGING_AUTO_EXPOSURE_SEC }
+    );
+
+    // Set the manual exposure level
     cam_.set_v4l_parameter("exposure_time_absolute", exposure_);
-    cam_.is_changing_config(false);
   }
 
   void checkAutoResetExposure(const ros::TimerEvent&)
   {
     if (enable_auto_reset_exposure_)
     {
-      resetExposureSettings();
+      std::thread t1(&UsbCamNode::resetExposureSettings, this);
+      t1.detach();
     }
   }
 

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -1209,6 +1209,7 @@ void UsbCam::set_v4l_parameter(const std::string& param, int value)
 */
 void UsbCam::set_v4l_parameter(const std::string& param, const std::string& value)
 {
+  is_changing_config(true);
   // build the command
   std::stringstream ss;
   ss << "v4l2-ctl --device=" << camera_dev_ << " -c " << param << "=" << value << " 2>&1";
@@ -1231,6 +1232,7 @@ void UsbCam::set_v4l_parameter(const std::string& param, const std::string& valu
   }
   else
     ROS_WARN("usb_cam_node could not run '%s'", cmd.c_str());
+  is_changing_config(false);
 }
 
 UsbCam::io_method UsbCam::io_method_from_string(const std::string& str)


### PR DESCRIPTION
- Add pause before setting the exposure level during the initial manual exposure cycle.
- Do the camera exposure cycling in a thread
- Unblock image publishing during the wait between camera setting changes