### PR TITLE
Backmerge 1.0.3 into develop for flippy-3.0.9.1.1-noetic

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,8 +23,8 @@ Changelog for package usb_cam
 * fix bug for byte count in a pixel (3 bytes not 24 bytes) (`#40 <https://github.com/ros-drivers/usb_cam/issues/40>`_ )
 * Contributors: Daniel Seifert, Eric Zavesky, Kei Okada, Ludovico Russo, Russell Toris, honeytrap15
 
-Forthcoming
------------
+1.0.3 (2024-10-16)
+------------------
 * Merge pull request `#68 <https://github.com/MisoRobotics/usb_cam/issues/68>`_ from MisoRobotics/user/hjoe72/fix/usb-cam-sn
   F3-8491: Fix USB camera SN matching
 * Fix USB camera SN matching

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,14 @@ Changelog for package usb_cam
 * fix bug for byte count in a pixel (3 bytes not 24 bytes) (`#40 <https://github.com/ros-drivers/usb_cam/issues/40>`_ )
 * Contributors: Daniel Seifert, Eric Zavesky, Kei Okada, Ludovico Russo, Russell Toris, honeytrap15
 
+Forthcoming
+-----------
+* Merge pull request `#68 <https://github.com/MisoRobotics/usb_cam/issues/68>`_ from MisoRobotics/user/hjoe72/fix/usb-cam-sn
+  F3-8491: Fix USB camera SN matching
+* Fix USB camera SN matching
+  Fix USB cameras SN matching.
+* Contributors: Hendry Joe, Zach Zweig Vinegar
+
 1.0.2 (2024-07-18)
 ------------------
 * Merge pull request `#65 <https://github.com/MisoRobotics/usb_cam/issues/65>`_ from MisoRobotics/user/hjoe72/feature/block-manual-reset

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>usb_cam</name>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <description>A ROS Driver for V4L USB Cameras</description>
 
   <maintainer email="rctoris@wpi.edu">Russell Toris</maintainer>


### PR DESCRIPTION
Backmerge finalized release 1.0.3 into develop.