### PR TITLE
F3-14132: Add support for IMX678 4K cameras

### DIFF
--- a/include/usb_cam/usb_cam.h
+++ b/include/usb_cam/usb_cam.h
@@ -150,7 +150,6 @@ class UsbCam {
   AVCodec *avcodec_;
   AVDictionary *avoptions_;
   AVCodecContext *avcodec_context_;
-  int avframe_camera_size_;
   int avframe_rgb_size_;
   struct SwsContext *video_sws_;
   camera_image_t *image_;

--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -42,6 +42,7 @@
 #include <camera_info_manager/camera_info_manager.h>
 #include <memory>
 #include <sstream>
+#include <vector>
 #include <std_srvs/Empty.h>
 #include <std_srvs/SetBool.h>
 #include <thread>
@@ -49,6 +50,22 @@
 #include <misocpp/diagnostic_updater_wrapper.h>
 
 namespace usb_cam {
+
+namespace
+{
+// udev lists e.g. /dev/video0; flippy-config may use /dev/v4l/by-path/... symlinks to the same node.
+std::string resolve_v4l_device_path(const std::string& p)
+{
+  try
+  {
+    return std::filesystem::weakly_canonical(p).string();
+  }
+  catch (const std::exception&)
+  {
+    return p;
+  }
+}
+}  // namespace
 
 //! \brief Manual Mode on V4L2 auto_exposure setting
 const int AUTO_EXPOSURE_MANUAL_MODE = 1;
@@ -96,13 +113,13 @@ public:
 
   ros::ServiceServer service_start_, service_stop_, service_auto_reset_exposure_, reset_exposure_;
 
-  bool service_start_cap(std_srvs::Empty::Request  &req, std_srvs::Empty::Response &res )
+  bool service_start_cap(std_srvs::Empty::Request&, std_srvs::Empty::Response&)
   {
     cam_.start_capturing();
     return true;
   }
 
-  bool reset_exposure_call(std_srvs::Empty::Request  &req, std_srvs::Empty::Response &res )
+  bool reset_exposure_call(std_srvs::Empty::Request&, std_srvs::Empty::Response&)
   {
     ros::Rate srv_rate(5);
     bool timeout = 20.0;
@@ -119,7 +136,7 @@ public:
     return true;
   }
 
-  bool service_stop_cap( std_srvs::Empty::Request  &req, std_srvs::Empty::Response &res )
+  bool service_stop_cap(std_srvs::Empty::Request&, std_srvs::Empty::Response&)
   {
     cam_.stop_capturing();
     return true;
@@ -190,23 +207,53 @@ public:
       str_map map_dev_serial = get_serial_dev_info();
       clear_unsupported_devices(map_dev_serial, pixel_format_name_);
 
-      bool found = false;
-      auto it = map_dev_serial.cbegin();
-      for (; it != map_dev_serial.cend(); ++it)
+      std::vector<std::string> serial_matches;
+      for (const auto& dev_serial : map_dev_serial)
       {
-        if (serial_number_ == it->second)
+        if (serial_number_ == dev_serial.second)
         {
-          found = true;
-          video_device_name_ = it->first;
-          break;
+          serial_matches.push_back(dev_serial.first);
         }
       }
 
-      if (!found)
+      if (serial_matches.empty())
       {
         ROS_FATAL("USB camera with serial number '%s' cannot be found.", serial_number_.c_str());
         node_.shutdown();
         return;
+      }
+
+      if (serial_matches.size() == 1)
+      {
+        video_device_name_ = serial_matches.front();
+      }
+      else
+      {
+        // Several V4L nodes can report the same USB serial; keep the `video_device` param (e.g. by-path)
+        // when it resolves to the same dev node as one of the udev entries.
+        const std::string wanted_resolved = resolve_v4l_device_path(video_device_name_);
+        bool device_ok = false;
+        for (const auto& path : serial_matches)
+        {
+          if (resolve_v4l_device_path(path) == wanted_resolved)
+          {
+            device_ok = true;
+            break;
+          }
+        }
+        if (!device_ok)
+        {
+          std::ostringstream oss;
+          oss << "USB serial '" << serial_number_ << "' matches several devices; set per-camera video_device "
+                 "in world_launch (e.g. /dev/v4l/by-path/...). Candidates:";
+          for (const auto& path : serial_matches)
+          {
+            oss << ' ' << path;
+          }
+          ROS_FATAL("%s", oss.str().c_str());
+          node_.shutdown();
+          return;
+        }
       }
     }
 

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -356,7 +356,7 @@ void rgb242rgb(char *YUV, char *RGB, int NumPixels)
 UsbCam::UsbCam()
   : io_(IO_METHOD_MMAP), fd_(-1), buffers_(NULL), n_buffers_(0), avframe_camera_(NULL),
     avframe_rgb_(NULL), avcodec_(NULL), avoptions_(NULL), avcodec_context_(NULL),
-    avframe_camera_size_(0), avframe_rgb_size_(0), video_sws_(NULL), image_(NULL),
+    avframe_rgb_size_(0), video_sws_(NULL), image_(NULL),
     is_capturing_(false), is_changing_config_(false) {
 }
 UsbCam::~UsbCam()
@@ -398,7 +398,6 @@ int UsbCam::init_mjpeg_decoder(int bits_per_pixel, int image_width, int image_he
   avcodec_context_->codec_type = AVMEDIA_TYPE_VIDEO;
 #endif
 
-  avframe_camera_size_ = avpicture_get_size(avcodec_pixel_format, image_width, image_height);
   avframe_rgb_size_ = avpicture_get_size(AV_PIX_FMT_RGB24, image_width, image_height);
 
   /* open it */
@@ -447,13 +446,8 @@ void UsbCam::mjpeg2rgb(char *MJPEG, int len, char *RGB, int NumPixels)
 
   int xsize = avcodec_context_->width;
   int ysize = avcodec_context_->height;
-  int pic_size = avpicture_get_size(avcodec_context_->pix_fmt, xsize, ysize);
-  if (pic_size != avframe_camera_size_)
-  {
-    ROS_ERROR("outbuf size mismatch.  pic_size: %d bufsize: %d", pic_size, avframe_camera_size_);
-    return;
-  }
-
+  // `bits_per_pixel` only hints the expected chroma layout at init; the bitstream may decode
+  // to YUV420P or YUV422P. sws_scale uses the actual `pix_fmt` after decode.
   video_sws_ = sws_getContext(xsize, ysize, avcodec_context_->pix_fmt, xsize, ysize, AV_PIX_FMT_RGB24, SWS_BILINEAR, NULL,
 			      NULL,  NULL);
   sws_scale(video_sws_, avframe_camera_->data, avframe_camera_->linesize, 0, ysize, avframe_rgb_->data,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes MJPEG decode validation logic and the serial-number-to-device resolution path, which can affect camera bring-up and runtime stability on multi-node V4L setups.
> 
> **Overview**
> Improves MJPEG handling by removing a strict decoded-buffer-size check and relying on the post-decode `pix_fmt` when converting to RGB, allowing streams whose actual chroma format differs from the `bits_per_pixel` hint (e.g., YUV420P vs YUV422P).
> 
> Makes serial-number based device selection more robust when a single USB serial matches multiple V4L nodes: it now validates the configured `video_device` (including `/dev/v4l/by-path/...` symlinks via canonicalization) against the matching candidates and fails with an explicit candidate list if ambiguous.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 666149433a2e8d5e17ddd0a630b4d777de064052. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->