### PR TITLE
MJPEG passthrough: publish compressed JPEG without CPU decode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package usb_cam
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Add optional ``mjpeg_passthrough`` parameter: publish ``image_raw/compressed`` (raw V4L MJPEG frame bytes, ``format: jpeg``) and ``camera_info`` without CPU decode; ``image_raw`` is not advertised in this mode.
+
 0.3.6 (2017-06-15)
 ------------------
 * .travis.yml: udpate to trusty

--- a/include/usb_cam/usb_cam.h
+++ b/include/usb_cam/usb_cam.h
@@ -54,8 +54,10 @@ extern "C"
 
 #include <string>
 #include <sstream>
+#include <vector>
 
 #include <sensor_msgs/Image.h>
+#include <sensor_msgs/CompressedImage.h>
 
 namespace usb_cam {
 
@@ -82,6 +84,11 @@ class UsbCam {
 
   // grabs a new image from the camera
   bool grab_image(sensor_msgs::Image* image);
+
+  /** MJPEG byte passthrough (no CPU decode). Call set_mjpeg_passthrough(true) before start(). */
+  bool grab_compressed_image(sensor_msgs::CompressedImage* image);
+
+  void set_mjpeg_passthrough(bool enabled) { mjpeg_passthrough_ = enabled; }
 
   // enables/disable auto focus
   void set_auto_focus(int value);
@@ -125,6 +132,7 @@ class UsbCam {
   int init_mjpeg_decoder(int bits_per_pixel, int image_width, int image_height);
   void mjpeg2rgb(char *MJPEG, int len, char *RGB, int NumPixels);
   void process_image(const void * src, int len, camera_image_t *dest);
+  void deliver_frame(const void *src, int len);
   int read_frame();
   void uninit_device(void);
   void init_read(unsigned int buffer_size);
@@ -155,7 +163,10 @@ class UsbCam {
   struct SwsContext *video_sws_;
   camera_image_t *image_;
 
+  bool mjpeg_passthrough_;
+  std::vector<uint8_t> mjpeg_frame_data_;
 };
+
 
 }
 

--- a/launch/usb_cam-mjpeg-passthrough.launch
+++ b/launch/usb_cam-mjpeg-passthrough.launch
@@ -1,0 +1,15 @@
+<launch>
+  <!-- Publishes ~/image_raw/compressed (sensor_msgs/CompressedImage, format jpeg) and ~/camera_info.
+       Does not publish ~/image_raw — avoids CPU MJPEG decode in usb_cam.
+       Use one downstream GPU decoder; republish image_raw for CPU nodes if needed. -->
+  <node name="usb_cam" pkg="usb_cam" type="usb_cam_node" output="screen">
+    <param name="video_device" value="/dev/video0"/>
+    <param name="image_width" value="1280"/>
+    <param name="image_height" value="720"/>
+    <param name="framerate" value="30"/>
+    <param name="pixel_format" value="mjpeg"/>
+    <param name="mjpeg_passthrough" value="true"/>
+    <param name="camera_frame_id" value="usb_cam"/>
+    <param name="io_method" value="mmap"/>
+  </node>
+</launch>

--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -34,12 +34,14 @@
 *
 *********************************************************************/
 
+#include <memory>
 #include <filesystem>
 
 #include <ros/ros.h>
 #include <usb_cam/usb_cam.h>
 #include <image_transport/image_transport.h>
 #include <camera_info_manager/camera_info_manager.h>
+#include <sensor_msgs/CompressedImage.h>
 #include <memory>
 #include <sstream>
 #include <std_srvs/Empty.h>
@@ -80,7 +82,11 @@ public:
 
   // shared image message
   sensor_msgs::Image img_;
-  image_transport::CameraPublisher image_pub_;
+  std::unique_ptr<image_transport::CameraPublisher> image_pub_;
+  bool mjpeg_passthrough_{ false };
+  sensor_msgs::CompressedImage compressed_img_;
+  ros::Publisher compressed_pub_;
+  ros::Publisher camera_info_pub_;
 
   // parameters
   std::string video_device_name_, io_method_name_, pixel_format_name_, camera_name_, camera_info_url_;
@@ -137,11 +143,7 @@ public:
   UsbCamNode() :
       node_("~")
   {
-    // advertise the main image topic
-    image_transport::ImageTransport it(node_);
-    image_pub_ = it.advertiseCamera("image_raw", 1);
-
-    // grab the parameters
+    // grab the parameters (before image_transport publishers)
     node_.param("serial_no", serial_number_, std::string(""));
     node_.param("video_device", video_device_name_, std::string("/dev/video0"));
     node_.param("brightness", brightness_, -1); //0-255, -1 "leave alone"
@@ -155,6 +157,7 @@ public:
     node_.param("framerate", framerate_, 30);
     // possible values: yuyv, uyvy, mjpeg, yuvmono10, rgb24
     node_.param("pixel_format", pixel_format_name_, std::string("mjpeg"));
+    node_.param("mjpeg_passthrough", mjpeg_passthrough_, false);
     node_.param("bits_per_pixel", bits_per_pixel_, 12);
     // enable/disable autofocus
     node_.param("autofocus", autofocus_, false);
@@ -175,7 +178,32 @@ public:
     node_.param("camera_frame_id", img_.header.frame_id, std::string("head_camera"));
     node_.param("camera_name", camera_name_, std::string("head_camera"));
     node_.param("camera_info_url", camera_info_url_, std::string(""));
+
+    if (mjpeg_passthrough_)
+    {
+      if (UsbCam::pixel_format_from_string(pixel_format_name_) != UsbCam::PIXEL_FORMAT_MJPEG)
+      {
+        ROS_FATAL("mjpeg_passthrough:=true requires pixel_format mjpeg (got '%s').", pixel_format_name_.c_str());
+        node_.shutdown();
+        return;
+      }
+    }
+
     cinfo_.reset(new camera_info_manager::CameraInfoManager(node_, camera_name_, camera_info_url_));
+
+    image_transport::ImageTransport it(node_);
+    if (!mjpeg_passthrough_)
+    {
+      image_pub_ = std::make_unique<image_transport::CameraPublisher>(it.advertiseCamera("image_raw", 1));
+    }
+    else
+    {
+      compressed_pub_ = node_.advertise<sensor_msgs::CompressedImage>("image_raw/compressed", 1);
+      camera_info_pub_ = node_.advertise<sensor_msgs::CameraInfo>("camera_info", 1);
+      ROS_WARN(
+          "usb_cam: mjpeg_passthrough enabled — publishing ~/image_raw/compressed (jpeg) and ~/camera_info only. "
+          "Use a single GPU decoder downstream; avoid multiple JPEG decompressors on this stream.");
+    }
 
     init_cam_reset_ = false;
 
@@ -245,6 +273,7 @@ public:
     }
 
     // start the camera
+    cam_.set_mjpeg_passthrough(mjpeg_passthrough_);
     cam_.start(video_device_name_.c_str(), io_method, pixel_format, bits_per_pixel_, image_width_,
 		     image_height_, framerate_);
 
@@ -335,7 +364,14 @@ public:
     std::string ns = ros::this_node::getNamespace();
     expected_freq_ = static_cast<double>(framerate_);
     std::filesystem::path topic = ns;
-    topic /= image_pub_.getTopic();
+    if (image_pub_)
+    {
+      topic /= image_pub_->getTopic();
+    }
+    else
+    {
+      topic /= "image_raw/compressed";
+    }
     diag_freq_image_raw_ =
         std::make_unique<misocpp::DiagnosticFrequency>(topic.c_str(), expected_freq_, expected_freq_);
     ROS_ASSERT(diag_freq_image_raw_);
@@ -364,15 +400,34 @@ public:
 
   bool take_and_send_image()
   {
-    // grab the image
-    if(!cam_.grab_image(&img_)) ros::shutdown();
-    // grab the camera info
     sensor_msgs::CameraInfoPtr ci(new sensor_msgs::CameraInfo(cinfo_->getCameraInfo()));
+
+    if (mjpeg_passthrough_)
+    {
+      if (!cam_.grab_compressed_image(&compressed_img_))
+      {
+        ros::shutdown();
+        return false;
+      }
+      compressed_img_.header.frame_id = img_.header.frame_id;
+      ci->header.frame_id = compressed_img_.header.frame_id;
+      ci->header.stamp = compressed_img_.header.stamp;
+      compressed_pub_.publish(compressed_img_);
+      camera_info_pub_.publish(*ci);
+      diag_freq_camera_info_->tick();
+      diag_freq_image_raw_->tick();
+      return true;
+    }
+
+    if (!cam_.grab_image(&img_))
+    {
+      ros::shutdown();
+      return false;
+    }
     ci->header.frame_id = img_.header.frame_id;
     ci->header.stamp = img_.header.stamp;
 
-    // publish the image
-    image_pub_.publish(img_, *ci);
+    image_pub_->publish(img_, *ci);
     diag_freq_camera_info_->tick();
     diag_freq_image_raw_->tick();
 

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -51,6 +51,7 @@
 #include <ros/ros.h>
 #include <boost/lexical_cast.hpp>
 #include <sensor_msgs/fill_image.h>
+#include <sensor_msgs/CompressedImage.h>
 
 #include <usb_cam/usb_cam.h>
 
@@ -357,7 +358,7 @@ UsbCam::UsbCam()
   : io_(IO_METHOD_MMAP), fd_(-1), buffers_(NULL), n_buffers_(0), avframe_camera_(NULL),
     avframe_rgb_(NULL), avcodec_(NULL), avoptions_(NULL), avcodec_context_(NULL),
     avframe_camera_size_(0), avframe_rgb_size_(0), video_sws_(NULL), image_(NULL),
-    is_capturing_(false), is_changing_config_(false) {
+    is_capturing_(false), is_changing_config_(false), mjpeg_passthrough_(false) {
 }
 UsbCam::~UsbCam()
 {
@@ -468,6 +469,22 @@ void UsbCam::mjpeg2rgb(char *MJPEG, int len, char *RGB, int NumPixels)
   }
 }
 
+void UsbCam::deliver_frame(const void *src, int len)
+{
+  if (pixelformat_ == V4L2_PIX_FMT_MJPEG && mjpeg_passthrough_)
+  {
+    mjpeg_frame_data_.resize(static_cast<size_t>(len));
+    if (len > 0 && src != nullptr)
+    {
+      memcpy(mjpeg_frame_data_.data(), src, static_cast<size_t>(len));
+    }
+  }
+  else
+  {
+    process_image(src, len, image_);
+  }
+}
+
 void UsbCam::process_image(const void * src, int len, camera_image_t *dest)
 {
   if (pixelformat_ == V4L2_PIX_FMT_YUYV)
@@ -518,7 +535,7 @@ int UsbCam::read_frame()
         }
       }
 
-      process_image(buffers_[0].start, len, image_);
+      deliver_frame(buffers_[0].start, len);
 
       break;
 
@@ -547,7 +564,7 @@ int UsbCam::read_frame()
 
       assert(buf.index < n_buffers_);
       len = buf.bytesused;
-      process_image(buffers_[buf.index].start, len, image_);
+      deliver_frame(buffers_[buf.index].start, len);
 
       if (-1 == xioctl(fd_, VIDIOC_QBUF, &buf))
         errno_exit("VIDIOC_QBUF");
@@ -583,7 +600,7 @@ int UsbCam::read_frame()
 
       assert(i < n_buffers_);
       len = buf.bytesused;
-      process_image((void *)buf.m.userptr, len, image_);
+      deliver_frame((void *)buf.m.userptr, len);
 
       if (-1 == xioctl(fd_, VIDIOC_QBUF, &buf))
         errno_exit("VIDIOC_QBUF");
@@ -1034,7 +1051,10 @@ void UsbCam::start(const std::string& dev, io_method io_method,
   else if (pixel_format == PIXEL_FORMAT_MJPEG)
   {
     pixelformat_ = V4L2_PIX_FMT_MJPEG;
-    init_mjpeg_decoder(bits_per_pixel, image_width, image_height);
+    if (!mjpeg_passthrough_)
+    {
+      init_mjpeg_decoder(bits_per_pixel, image_width, image_height);
+    }
   }
   else if (pixel_format == PIXEL_FORMAT_YUVMONO10)
   {
@@ -1067,10 +1087,18 @@ void UsbCam::start(const std::string& dev, io_method io_method,
   image_->height = image_height;
   image_->bytes_per_pixel = 3;      //corrected 11/10/15 (BYTES not BITS per pixel)
 
-  image_->image_size = image_->width * image_->height * image_->bytes_per_pixel;
   image_->is_new = 0;
-  image_->image = (char *)calloc(image_->image_size, sizeof(char));
-  memset(image_->image, 0, image_->image_size * sizeof(char));
+  if (mjpeg_passthrough_ && pixelformat_ == V4L2_PIX_FMT_MJPEG)
+  {
+    image_->image_size = 0;
+    image_->image = nullptr;
+  }
+  else
+  {
+    image_->image_size = image_->width * image_->height * image_->bytes_per_pixel;
+    image_->image = (char *)calloc(image_->image_size, sizeof(char));
+    memset(image_->image, 0, image_->image_size * sizeof(char));
+  }
 }
 
 void UsbCam::shutdown(void)
@@ -1091,13 +1119,24 @@ void UsbCam::shutdown(void)
   if (avframe_rgb_)
     av_free(avframe_rgb_);
   avframe_rgb_ = NULL;
-  if(image_)
+  if (image_)
+  {
+    if (image_->image)
+      free(image_->image);
     free(image_);
+  }
   image_ = NULL;
 }
 
 bool UsbCam::grab_image(sensor_msgs::Image* msg)
 {
+  if (pixelformat_ == V4L2_PIX_FMT_MJPEG && mjpeg_passthrough_)
+  {
+    ROS_ERROR_THROTTLE(
+        5.0,
+        "grab_image(sensor_msgs::Image): MJPEG passthrough is enabled; use grab_compressed_image instead.");
+    return false;
+  }
   // grab the image
   if (!grab_image()) return false;
   // stamp the image
@@ -1113,6 +1152,29 @@ bool UsbCam::grab_image(sensor_msgs::Image* msg)
     fillImage(*msg, "rgb8", image_->height, image_->width, 3 * image_->width,
         image_->image);
   }
+  return true;
+}
+
+bool UsbCam::grab_compressed_image(sensor_msgs::CompressedImage* msg)
+{
+  if (!(pixelformat_ == V4L2_PIX_FMT_MJPEG && mjpeg_passthrough_))
+  {
+    ROS_ERROR_THROTTLE(
+        5.0,
+        "grab_compressed_image: requires pixel_format mjpeg and mjpeg_passthrough enabled before start()");
+    return false;
+  }
+  if (msg == nullptr)
+  {
+    return false;
+  }
+  if (!grab_image())
+  {
+    return false;
+  }
+  msg->header.stamp = ros::Time::now();
+  msg->format = "jpeg";
+  msg->data = mjpeg_frame_data_;
   return true;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change implements **plan phase E** for the GPU decode pipeline: `usb_cam` can publish **raw V4L MJPEG frames** as `sensor_msgs/CompressedImage` (`format: jpeg`) on `~/image_raw/compressed` plus `~/camera_info`, with **no FFmpeg / libswscale** on the capture path and **no `image_raw` advertisement** in that mode (so RViz and other tools do not pull an extra decode path).

## Usage

- Set private param **`mjpeg_passthrough`** to `true` (requires **`pixel_format`** `mjpeg`).
- Example launch: `launch/usb_cam-mjpeg-passthrough.launch`.

## Downstream (follow-up work outside this repo)

1. **Single GPU decoder node** (plan phase C): subscribe only to `.../image_raw/compressed`, decode once on the RTX A1000, then publish `image_raw` (or feed chippy/fiducial) so **aruco/template** still see one CPU buffer if needed.
2. **chippy / fiducials**: stop subscribing to raw `image_raw` from `usb_cam` when passthrough is enabled; subscribe either to the decoder output or chain in-process (nodelets) to avoid duplicate full-frame copies.
3. **flippy-config / bringup**: pass `mjpeg_passthrough` and remap topics for the new graph; ensure nothing else subscribes to `image_raw/compressed` for a second JPEG decode.

## Other

- `UsbCam::shutdown` now frees `image_->image` before freeing the `camera_image_t` struct (fixes a latent leak when a pixel buffer was allocated).

EOF

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac376b75-e9e7-4115-825a-539e94f0e2e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac376b75-e9e7-4115-825a-539e94f0e2e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

