### PR TITLE
F3-14174: Reduce compute usage by only grabbing images at fryer inspection

### DIFF
--- a/include/usb_cam/usb_cam.h
+++ b/include/usb_cam/usb_cam.h
@@ -97,6 +97,9 @@ class UsbCam {
   // Get the actual pixel format for MJPEG video from bits per pixels
   static AVPixelFormat get_avcodec_pixel_format(int bits_per_pixel);
 
+  /** When true (MJPEG only), publish decoded Y (luma) plane as mono8 instead of RGB. */
+  void set_publish_luma_only(bool publish_luma_only);
+
   void stop_capturing(void);
   void start_capturing(void);
   bool is_capturing();
@@ -124,6 +127,7 @@ class UsbCam {
 
   int init_mjpeg_decoder(int bits_per_pixel, int image_width, int image_height);
   void mjpeg2rgb(char *MJPEG, int len, char *RGB, int NumPixels);
+  void mjpeg2luma(char *MJPEG, int len, char *luma, int num_pixels);
   void process_image(const void * src, int len, camera_image_t *dest);
   int read_frame();
   void uninit_device(void);
@@ -141,6 +145,7 @@ class UsbCam {
   std::string camera_dev_;
   unsigned int pixelformat_;
   bool monochrome_;
+  bool publish_luma_only_;
   io_method io_;
   int fd_;
   buffer * buffers_;

--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -36,6 +36,10 @@
 
 #include <filesystem>
 
+#include <algorithm>
+#include <cmath>
+#include <mutex>
+
 #include <ros/ros.h>
 #include <usb_cam/usb_cam.h>
 #include <image_transport/image_transport.h>
@@ -46,6 +50,7 @@
 #include <std_srvs/Empty.h>
 #include <std_srvs/SetBool.h>
 #include <thread>
+#include <sensor_msgs/JointState.h>
 #include <usb_cam/device_utils.h>
 #include <misocpp/diagnostic_updater_wrapper.h>
 
@@ -64,6 +69,81 @@ std::string resolve_v4l_device_path(const std::string& p)
   {
     return p;
   }
+}
+
+bool getOrderedJointPositions(const sensor_msgs::JointState& msg,
+                              const std::vector<std::string>& joint_names,
+                              std::vector<double>* positions)
+{
+  if (!positions)
+  {
+    return false;
+  }
+  positions->clear();
+  positions->reserve(joint_names.size());
+  for (const auto& joint_name : joint_names)
+  {
+    const auto it = std::find(msg.name.begin(), msg.name.end(), joint_name);
+    if (it == msg.name.end())
+    {
+      return false;
+    }
+    const size_t idx = static_cast<size_t>(std::distance(msg.name.begin(), it));
+    if (idx >= msg.position.size())
+    {
+      return false;
+    }
+    positions->push_back(msg.position[idx]);
+  }
+  return true;
+}
+
+bool jointsNearTarget(const std::vector<double>& current,
+                      const std::vector<double>& target,
+                      double tolerance)
+{
+  if (current.size() != target.size())
+  {
+    return false;
+  }
+  for (size_t i = 0; i < current.size(); ++i)
+  {
+    if (std::abs(current[i] - target[i]) > tolerance)
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+// /joint_states is merged arm-then-rail (joint_state_filter: r1 then s1).
+const std::vector<std::string> kJointStatesOrder = {
+    "joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6", "slider_1"};
+
+// /behaviors/points/* use /miso/joint_map order (slider_1, joint_1, ... joint_6).
+bool reorderFromJointMapOrder(const std::vector<double>& joint_map_order,
+                              const std::vector<std::string>& joint_map,
+                              const std::vector<std::string>& output_order,
+                              std::vector<double>* output)
+{
+  if (!output || joint_map_order.size() != joint_map.size())
+  {
+    return false;
+  }
+
+  output->clear();
+  output->reserve(output_order.size());
+  for (const auto& joint_name : output_order)
+  {
+    const auto it = std::find(joint_map.begin(), joint_map.end(), joint_name);
+    if (it == joint_map.end())
+    {
+      return false;
+    }
+    const size_t idx = static_cast<size_t>(std::distance(joint_map.begin(), it));
+    output->push_back(joint_map_order[idx]);
+  }
+  return true;
 }
 }  // namespace
 
@@ -112,6 +192,16 @@ public:
   UsbCam cam_;
 
   ros::ServiceServer service_start_, service_stop_, service_auto_reset_exposure_, reset_exposure_;
+  ros::Subscriber joint_states_sub_;
+
+  bool gate_capture_on_joint_state_;
+  std::string joint_states_topic_;
+  std::vector<std::string> joint_names_;
+  std::vector<double> fryer_inspection_joints_;
+  double joint_position_tolerance_;
+  std::mutex joint_state_mutex_;
+  bool has_joint_state_;
+  bool at_fryer_inspection_joints_;
 
   bool service_start_cap(std_srvs::Empty::Request&, std_srvs::Empty::Response&)
   {
@@ -149,10 +239,48 @@ public:
     res.message = "";
     return true;
   }
-  
+
+  void jointStatesCallback(const sensor_msgs::JointStateConstPtr& msg)
+  {
+    if (!gate_capture_on_joint_state_)
+    {
+      return;
+    }
+
+    std::vector<double> current_joints;
+    if (!getOrderedJointPositions(*msg, joint_names_, &current_joints))
+    {
+      return;
+    }
+
+    const bool at_target = jointsNearTarget(
+        current_joints, fryer_inspection_joints_, joint_position_tolerance_);
+
+    {
+      std::lock_guard<std::mutex> lock(joint_state_mutex_);
+      has_joint_state_ = true;
+      at_fryer_inspection_joints_ = at_target;
+    }
+  }
+
+  bool shouldCaptureFrame()
+  {
+    if (!gate_capture_on_joint_state_)
+    {
+      return true;
+    }
+
+    std::lock_guard<std::mutex> lock(joint_state_mutex_);
+    return has_joint_state_ && at_fryer_inspection_joints_;
+  }
 
   UsbCamNode() :
-      node_("~")
+      node_("~"),
+      gate_capture_on_joint_state_(false),
+      joint_states_topic_("/joint_states"),
+      joint_position_tolerance_(0.05),
+      has_joint_state_(false),
+      at_fryer_inspection_joints_(false)
   {
     // advertise the main image topic
     image_transport::ImageTransport it(node_);
@@ -191,6 +319,62 @@ public:
     // load the camera info
     node_.param("camera_frame_id", img_.header.frame_id, std::string("head_camera"));
     node_.param("camera_name", camera_name_, std::string("head_camera"));
+
+    node_.param("joint_states_topic", joint_states_topic_, joint_states_topic_);
+    node_.param("joint_position_tolerance", joint_position_tolerance_, joint_position_tolerance_);
+    node_.param("gate_capture_on_joint_state", gate_capture_on_joint_state_, gate_capture_on_joint_state_);
+
+    const bool is_fryer_camera = camera_name_.compare(0, 9, "fryer_cam") == 0;
+    if (is_fryer_camera || gate_capture_on_joint_state_)
+    {
+      ros::NodeHandle nh;
+      std::vector<double> fryer_inspection_joint_map_order;
+      if (!nh.getParam("/behaviors/points/fryer_inspection", fryer_inspection_joint_map_order) ||
+          fryer_inspection_joint_map_order.empty())
+      {
+        ROS_WARN(
+            "%s: /behaviors/points/fryer_inspection not available; capture is not gated on joint state.",
+            camera_name_.c_str());
+        gate_capture_on_joint_state_ = false;
+      }
+      else
+      {
+        std::vector<std::string> joint_map;
+        if (!nh.getParam("/miso/joint_map", joint_map))
+        {
+          ROS_FATAL(
+              "%s: joint gating requires /miso/joint_map to interpret /behaviors/points/fryer_inspection.",
+              camera_name_.c_str());
+          node_.shutdown();
+          return;
+        }
+
+        if (joint_map.size() != fryer_inspection_joint_map_order.size())
+        {
+          ROS_FATAL(
+              "%s: /miso/joint_map (%zu) and /behaviors/points/fryer_inspection (%zu) must have the same length.",
+              camera_name_.c_str(), joint_map.size(), fryer_inspection_joint_map_order.size());
+          node_.shutdown();
+          return;
+        }
+
+        if (!reorderFromJointMapOrder(
+                fryer_inspection_joint_map_order, joint_map, kJointStatesOrder, &fryer_inspection_joints_))
+        {
+          ROS_FATAL(
+              "%s: failed to reorder fryer_inspection joints to /joint_states order (joint_1..joint_6, slider_1).",
+              camera_name_.c_str());
+          node_.shutdown();
+          return;
+        }
+
+        joint_names_ = kJointStatesOrder;
+        gate_capture_on_joint_state_ = true;
+
+        joint_states_sub_ = node_.subscribe(
+            joint_states_topic_, 1, &UsbCamNode::jointStatesCallback, this);
+      }
+    }
     node_.param("camera_info_url", camera_info_url_, std::string(""));
     cinfo_.reset(new camera_info_manager::CameraInfoManager(node_, camera_name_, camera_info_url_));
 
@@ -257,9 +441,21 @@ public:
       }
     }
 
-    // check for default camera info
-    if (!cinfo_->isCalibrated())
+    if (cinfo_->isCalibrated())
     {
+      ROS_INFO(
+          "%s: loaded camera intrinsics from %s",
+          camera_name_.c_str(),
+          camera_info_url_.empty() ? "camera_info_manager default" : camera_info_url_.c_str());
+    }
+    else
+    {
+      if (!camera_info_url_.empty())
+      {
+        ROS_WARN(
+            "%s: failed to load camera intrinsics from '%s'; aruco_detect will warn about K matrix zeros.",
+            camera_name_.c_str(), camera_info_url_.c_str());
+      }
       cinfo_->setCameraName(video_device_name_);
       sensor_msgs::CameraInfo camera_info;
       camera_info.header.frame_id = img_.header.frame_id;
@@ -463,8 +659,14 @@ public:
     ros::Rate loop_rate(this->framerate_);
     while (node_.ok())
     {
-      if (cam_.is_capturing() && !cam_.is_changing_config()) {
-        if (!take_and_send_image()) ROS_WARN("USB camera did not respond in time.");
+      const bool ready_to_capture =
+          cam_.is_capturing() && !cam_.is_changing_config();
+      if (ready_to_capture && shouldCaptureFrame())
+      {
+        if (!take_and_send_image())
+        {
+          ROS_WARN("USB camera did not respond in time.");
+        }
       }
       heartbeat_.update();
       loop_rate.sleep();

--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -320,6 +320,9 @@ public:
     node_.param("camera_frame_id", img_.header.frame_id, std::string("head_camera"));
     node_.param("camera_name", camera_name_, std::string("head_camera"));
 
+    bool publish_luma_only = (camera_name_.compare(0, 9, "fryer_cam") == 0);
+    node_.param("publish_luma_only", publish_luma_only, publish_luma_only);
+
     node_.param("joint_states_topic", joint_states_topic_, joint_states_topic_);
     node_.param("joint_position_tolerance", joint_position_tolerance_, joint_position_tolerance_);
     node_.param("gate_capture_on_joint_state", gate_capture_on_joint_state_, gate_capture_on_joint_state_);
@@ -465,9 +468,20 @@ public:
     }
 
 
-    ROS_INFO("Starting '%s' (%s) at %dx%d via %s (%s %d bpp) at %i FPS", camera_name_.c_str(),
-             video_device_name_.c_str(), image_width_, image_height_, io_method_name_.c_str(),
-             pixel_format_name_.c_str(), bits_per_pixel_, framerate_);
+    if (publish_luma_only && pixel_format_name_ != "mjpeg")
+    {
+      ROS_WARN(
+          "%s: publish_luma_only requires pixel_format mjpeg; publishing full color instead.",
+          camera_name_.c_str());
+      publish_luma_only = false;
+    }
+    cam_.set_publish_luma_only(publish_luma_only);
+
+    ROS_INFO(
+        "Starting '%s' (%s) at %dx%d via %s (%s %d bpp) at %i FPS%s", camera_name_.c_str(),
+        video_device_name_.c_str(), image_width_, image_height_, io_method_name_.c_str(),
+        pixel_format_name_.c_str(), bits_per_pixel_, framerate_,
+        publish_luma_only ? " [MJPEG luma -> mono8]" : "");
 
     // set the IO method
     UsbCam::io_method io_method = UsbCam::io_method_from_string(io_method_name_);
@@ -608,7 +622,10 @@ public:
   bool take_and_send_image()
   {
     // grab the image
-    if(!cam_.grab_image(&img_)) ros::shutdown();
+    if (!cam_.grab_image(&img_))
+    {
+      ros::shutdown();
+    }
     // grab the camera info
     sensor_msgs::CameraInfoPtr ci(new sensor_msgs::CameraInfo(cinfo_->getCameraInfo()));
     ci->header.frame_id = img_.header.frame_id;

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -34,6 +34,7 @@
  *
  *********************************************************************/
 #define __STDC_CONSTANT_MACROS
+#include <algorithm>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -357,7 +358,12 @@ UsbCam::UsbCam()
   : io_(IO_METHOD_MMAP), fd_(-1), buffers_(NULL), n_buffers_(0), avframe_camera_(NULL),
     avframe_rgb_(NULL), avcodec_(NULL), avoptions_(NULL), avcodec_context_(NULL),
     avframe_rgb_size_(0), video_sws_(NULL), image_(NULL),
-    is_capturing_(false), is_changing_config_(false) {
+    is_capturing_(false), is_changing_config_(false), publish_luma_only_(false) {
+}
+
+void UsbCam::set_publish_luma_only(bool publish_luma_only)
+{
+  publish_luma_only_ = publish_luma_only;
 }
 UsbCam::~UsbCam()
 {
@@ -380,13 +386,23 @@ int UsbCam::init_mjpeg_decoder(int bits_per_pixel, int image_width, int image_he
   avcodec_context_ = avcodec_alloc_context3(avcodec_);
 #if LIBAVCODEC_VERSION_MAJOR < 55
   avframe_camera_ = avcodec_alloc_frame();
-  avframe_rgb_ = avcodec_alloc_frame();
 #else
   avframe_camera_ = av_frame_alloc();
-  avframe_rgb_ = av_frame_alloc();
 #endif
 
-  avpicture_alloc((AVPicture *)avframe_rgb_, AV_PIX_FMT_RGB24, image_width, image_height);
+  if (!publish_luma_only_)
+  {
+#if LIBAVCODEC_VERSION_MAJOR < 55
+    avframe_rgb_ = avcodec_alloc_frame();
+#else
+    avframe_rgb_ = av_frame_alloc();
+#endif
+    avpicture_alloc((AVPicture *)avframe_rgb_, AV_PIX_FMT_RGB24, image_width, image_height);
+  }
+  else
+  {
+    avframe_rgb_ = NULL;
+  }
 
   avcodec_context_->codec_id = AV_CODEC_ID_MJPEG;
   avcodec_context_->width = image_width;
@@ -398,7 +414,9 @@ int UsbCam::init_mjpeg_decoder(int bits_per_pixel, int image_width, int image_he
   avcodec_context_->codec_type = AVMEDIA_TYPE_VIDEO;
 #endif
 
-  avframe_rgb_size_ = avpicture_get_size(AV_PIX_FMT_RGB24, image_width, image_height);
+  avframe_rgb_size_ = publish_luma_only_ ?
+      image_width * image_height :
+      avpicture_get_size(AV_PIX_FMT_RGB24, image_width, image_height);
 
   /* open it */
   if (avcodec_open2(avcodec_context_, avcodec_, &avoptions_) < 0)
@@ -462,6 +480,113 @@ void UsbCam::mjpeg2rgb(char *MJPEG, int len, char *RGB, int NumPixels)
   }
 }
 
+namespace {
+
+void copy_y_plane_to_buffer(const AVFrame* frame, int width, int height, char* dest)
+{
+  const uint8_t* src = frame->data[0];
+  const int src_stride = frame->linesize[0];
+  for (int row = 0; row < height; ++row)
+  {
+    memcpy(dest + row * width, src + row * src_stride, width);
+  }
+}
+
+}  // namespace
+
+void UsbCam::mjpeg2luma(char *MJPEG, int len, char *luma, int num_pixels)
+{
+  int got_picture;
+
+  memset(luma, 0, avframe_rgb_size_);
+
+#if LIBAVCODEC_VERSION_MAJOR > 52
+  int decoded_len;
+  AVPacket avpkt;
+  av_init_packet(&avpkt);
+
+  avpkt.size = len;
+  avpkt.data = (unsigned char*)MJPEG;
+  decoded_len = avcodec_decode_video2(avcodec_context_, avframe_camera_, &got_picture, &avpkt);
+
+  if (decoded_len < 0)
+  {
+    ROS_ERROR("Error while decoding frame.");
+    return;
+  }
+#else
+  avcodec_decode_video(avcodec_context_, avframe_camera_, &got_picture, (uint8_t *) MJPEG, len);
+#endif
+
+  if (!got_picture)
+  {
+    ROS_ERROR("Webcam: expected picture but didn't get it...");
+    return;
+  }
+
+  AVPixelFormat pix_fmt = avcodec_context_->pix_fmt;
+  if (pix_fmt == AV_PIX_FMT_YUVJ420P)
+  {
+    pix_fmt = AV_PIX_FMT_YUV420P;
+  }
+  else if (pix_fmt == AV_PIX_FMT_YUVJ422P)
+  {
+    pix_fmt = AV_PIX_FMT_YUV422P;
+  }
+
+  const int xsize = avcodec_context_->width;
+  const int ysize = avcodec_context_->height;
+
+  if (pix_fmt == AV_PIX_FMT_YUV420P || pix_fmt == AV_PIX_FMT_YUV422P)
+  {
+    if (xsize * ysize != num_pixels)
+    {
+      ROS_WARN_THROTTLE(
+          5.0, "MJPEG decoded size %dx%d differs from buffer %d pixels; copying min region",
+          xsize, ysize, num_pixels);
+    }
+    const int copy_w = std::min(xsize, image_->width);
+    const int copy_h = std::min(ysize, image_->height);
+    copy_y_plane_to_buffer(avframe_camera_, copy_w, copy_h, luma);
+    return;
+  }
+
+  // Unusual chroma layout: fall back to grayscale conversion via swscale.
+  video_sws_ = sws_getContext(
+      xsize, ysize, avcodec_context_->pix_fmt, xsize, ysize, AV_PIX_FMT_GRAY8, SWS_BILINEAR, NULL, NULL, NULL);
+  if (!video_sws_)
+  {
+    ROS_ERROR("webcam: sws_getContext failed for luma fallback (pix_fmt=%d)", avcodec_context_->pix_fmt);
+    return;
+  }
+
+#if LIBAVCODEC_VERSION_MAJOR < 55
+  AVFrame* gray_frame = avcodec_alloc_frame();
+#else
+  AVFrame* gray_frame = av_frame_alloc();
+#endif
+  avpicture_alloc((AVPicture*)gray_frame, AV_PIX_FMT_GRAY8, xsize, ysize);
+
+  sws_scale(
+      video_sws_, avframe_camera_->data, avframe_camera_->linesize, 0, ysize, gray_frame->data, gray_frame->linesize);
+  sws_freeContext(video_sws_);
+  video_sws_ = NULL;
+
+  const int copy_w = std::min(xsize, image_->width);
+  const int copy_h = std::min(ysize, image_->height);
+  const int gray_stride = gray_frame->linesize[0];
+  for (int row = 0; row < copy_h; ++row)
+  {
+    memcpy(luma + row * image_->width, gray_frame->data[0] + row * gray_stride, copy_w);
+  }
+
+#if LIBAVCODEC_VERSION_MAJOR < 55
+  av_free(gray_frame);
+#else
+  av_frame_free(&gray_frame);
+#endif
+}
+
 void UsbCam::process_image(const void * src, int len, camera_image_t *dest)
 {
   if (pixelformat_ == V4L2_PIX_FMT_YUYV)
@@ -478,7 +603,12 @@ void UsbCam::process_image(const void * src, int len, camera_image_t *dest)
   else if (pixelformat_ == V4L2_PIX_FMT_UYVY)
     uyvy2rgb((char*)src, dest->image, dest->width * dest->height);
   else if (pixelformat_ == V4L2_PIX_FMT_MJPEG)
-    mjpeg2rgb((char*)src, len, dest->image, dest->width * dest->height);
+  {
+    if (publish_luma_only_)
+      mjpeg2luma((char*)src, len, dest->image, dest->width * dest->height);
+    else
+      mjpeg2rgb((char*)src, len, dest->image, dest->width * dest->height);
+  }
   else if (pixelformat_ == V4L2_PIX_FMT_RGB24)
     rgb242rgb((char*)src, dest->image, dest->width * dest->height);
   else if (pixelformat_ == V4L2_PIX_FMT_GREY)
@@ -1059,7 +1189,8 @@ void UsbCam::start(const std::string& dev, io_method io_method,
 
   image_->width = image_width;
   image_->height = image_height;
-  image_->bytes_per_pixel = 3;      //corrected 11/10/15 (BYTES not BITS per pixel)
+  const bool mono_output = monochrome_ || (publish_luma_only_ && pixelformat_ == V4L2_PIX_FMT_MJPEG);
+  image_->bytes_per_pixel = mono_output ? 1 : 3;  // BYTES per pixel (not bits)
 
   image_->image_size = image_->width * image_->height * image_->bytes_per_pixel;
   image_->is_new = 0;
@@ -1097,7 +1228,7 @@ bool UsbCam::grab_image(sensor_msgs::Image* msg)
   // stamp the image
   msg->header.stamp = ros::Time::now();
   // fill the info
-  if (monochrome_)
+  if (monochrome_ || publish_luma_only_)
   {
     fillImage(*msg, "mono8", image_->height, image_->width, image_->width,
         image_->image);


### PR DESCRIPTION
This prevents the usb cam node from doing normal operation unless the robot is at the fryer inspection joints. This reduces the CPU usage.