### PR TITLE
F3-1425: Publish mjpeg images to new image_compressed topic

### DIFF
--- a/include/usb_cam/usb_cam.h
+++ b/include/usb_cam/usb_cam.h
@@ -55,7 +55,9 @@ extern "C"
 #include <string>
 #include <sstream>
 
+#include <sensor_msgs/CompressedImage.h>
 #include <sensor_msgs/Image.h>
+#include <vector>
 
 namespace usb_cam {
 
@@ -82,6 +84,9 @@ class UsbCam {
 
   // grabs a new image from the camera
   bool grab_image(sensor_msgs::Image* image);
+
+  // Fills msg with the last MJPEG frame from the camera (pixel_format mjpeg only).
+  bool fill_compressed_image(sensor_msgs::CompressedImage* msg);
 
   // enables/disable auto focus
   void set_auto_focus(int value);
@@ -162,6 +167,7 @@ class UsbCam {
   int avframe_rgb_size_;
   struct SwsContext *video_sws_;
   camera_image_t *image_;
+  std::vector<uint8_t> mjpeg_frame_;
 
 };
 

--- a/nodes/usb_cam_node.cpp
+++ b/nodes/usb_cam_node.cpp
@@ -39,6 +39,7 @@
 #include <ros/ros.h>
 #include <usb_cam/usb_cam.h>
 #include <image_transport/image_transport.h>
+#include <sensor_msgs/CompressedImage.h>
 #include <camera_info_manager/camera_info_manager.h>
 #include <memory>
 #include <sstream>
@@ -97,7 +98,9 @@ public:
 
   // shared image message
   sensor_msgs::Image img_;
+  sensor_msgs::CompressedImage compressed_img_;
   image_transport::CameraPublisher image_pub_;
+  ros::Publisher compressed_image_pub_;
 
   // parameters
   std::string video_device_name_, io_method_name_, pixel_format_name_, camera_name_, camera_info_url_;
@@ -157,6 +160,8 @@ public:
     // advertise the main image topic
     image_transport::ImageTransport it(node_);
     image_pub_ = it.advertiseCamera("image_raw", 1);
+    compressed_image_pub_ =
+        node_.advertise<sensor_msgs::CompressedImage>("image_compressed", 1);
 
     // grab the parameters
     node_.param("serial_no", serial_number_, std::string(""));
@@ -286,6 +291,12 @@ public:
         video_device_name_.c_str(), image_width_, image_height_, io_method_name_.c_str(),
         pixel_format_name_.c_str(), bits_per_pixel_, framerate_,
         publish_luma_only ? " [MJPEG luma -> mono8]" : "");
+    if (pixel_format_name_ != "mjpeg")
+    {
+      ROS_WARN(
+          "%s: image_compressed is only published when pixel_format is mjpeg.",
+          camera_name_.c_str());
+    }
 
     // set the IO method
     UsbCam::io_method io_method = UsbCam::io_method_from_string(io_method_name_);
@@ -439,6 +450,12 @@ public:
     image_pub_.publish(img_, *ci);
     diag_freq_camera_info_->tick();
     diag_freq_image_raw_->tick();
+
+    compressed_img_.header = img_.header;
+    if (cam_.fill_compressed_image(&compressed_img_))
+    {
+      compressed_image_pub_.publish(compressed_img_);
+    }
 
     return true;
   }

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -1195,7 +1195,7 @@ bool UsbCam::fill_compressed_image(sensor_msgs::CompressedImage* msg)
     return false;
   }
   msg->format = "jpeg";
-  msg->data = mjpeg_frame_;
+  msg->data.swap(mjpeg_frame_);
   return true;
 }
 

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -561,6 +561,7 @@ void UsbCam::process_image(const void * src, int len, camera_image_t *dest)
     uyvy2rgb((char*)src, dest->image, dest->width * dest->height);
   else if (pixelformat_ == V4L2_PIX_FMT_MJPEG)
   {
+    mjpeg_frame_.assign(static_cast<const uint8_t*>(src), static_cast<const uint8_t*>(src) + len);
     if (publish_luma_only_)
       mjpeg2luma((char*)src, len, dest->image, dest->width * dest->height);
     else
@@ -1185,6 +1186,17 @@ void UsbCam::shutdown(void)
   if(image_)
     free(image_);
   image_ = NULL;
+}
+
+bool UsbCam::fill_compressed_image(sensor_msgs::CompressedImage* msg)
+{
+  if (pixelformat_ != V4L2_PIX_FMT_MJPEG || mjpeg_frame_.empty())
+  {
+    return false;
+  }
+  msg->format = "jpeg";
+  msg->data = mjpeg_frame_;
+  return true;
 }
 
 bool UsbCam::grab_image(sensor_msgs::Image* msg)


### PR DESCRIPTION

- USB Cam node publishes jpeg images to new image_compressed topic before decompressing 
- Image raw topic is unchanged 
- Error rosbag size reduces by 80%


<img width="1146" height="241" alt="image" src="https://github.com/user-attachments/assets/ec926352-d54c-436f-9f4b-deee3ba04f28" />

Merge with [chippy PR](https://github.com/MisoRobotics/chippy/pull/2300)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive topic and buffer copy on the MJPEG path; existing decoded `image_raw` publishing is unchanged.
> 
> **Overview**
> Adds a parallel **`image_compressed`** topic (`sensor_msgs/CompressedImage`, format `jpeg`) so consumers can record or use the camera’s native MJPEG stream without changing **`image_raw`** / `camera_info` behavior.
> 
> For **MJPEG** captures, `UsbCam` now keeps each V4L frame’s compressed bytes in `mjpeg_frame_` during `process_image`, then `fill_compressed_image` moves them into the message (still decoding to rgb8/mono8 for `image_raw` as before). The node advertises the topic, warns at startup if `pixel_format` is not `mjpeg`, and publishes compressed data on each successful grab when available.
> 
> **Risk:** Low—additive ROS API and buffering on the existing capture path; no change to decoded image semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ea407670356d79d91e8b39f62dc490ecf31e41f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->