### PR TITLE
Backmerge 1.1.2 into develop for flippy-3.5.2-noetic

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,15 @@ Changelog for package usb_cam
 * fix bug for byte count in a pixel (3 bytes not 24 bytes) (`#40 <https://github.com/ros-drivers/usb_cam/issues/40>`_ )
 * Contributors: Daniel Seifert, Eric Zavesky, Kei Okada, Ludovico Russo, Russell Toris, honeytrap15
 
+Forthcoming
+-----------
+* Merge pull request `#80 <https://github.com/MisoRobotics/usb_cam/issues/80>`_ from MisoRobotics/user/ssarfraz/feature/log-compressed-images
+  Publish mjpeg images to new image_compressed topic
+* Publish mjpeg images to new image_compressed topic
+* Merge pull request `#79 <https://github.com/MisoRobotics/usb_cam/issues/79>`_ from MisoRobotics/master
+  Merge pull request `#76 <https://github.com/MisoRobotics/usb_cam/issues/76>`_ from MisoRobotics/release/1.1.1
+* Contributors: Sana Sarfraz, Winnie Lam
+
 1.1.1 (2026-05-26)
 ------------------
 * Merge pull request `#75 <https://github.com/MisoRobotics/usb_cam/issues/75>`_ from MisoRobotics/user/ykojitani/dev/publish-images-in-grayscale

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,8 +23,8 @@ Changelog for package usb_cam
 * fix bug for byte count in a pixel (3 bytes not 24 bytes) (`#40 <https://github.com/ros-drivers/usb_cam/issues/40>`_ )
 * Contributors: Daniel Seifert, Eric Zavesky, Kei Okada, Ludovico Russo, Russell Toris, honeytrap15
 
-Forthcoming
------------
+1.1.2 (2026-06-01)
+------------------
 * Merge pull request `#80 <https://github.com/MisoRobotics/usb_cam/issues/80>`_ from MisoRobotics/user/ssarfraz/feature/log-compressed-images
   Publish mjpeg images to new image_compressed topic
 * Publish mjpeg images to new image_compressed topic

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>usb_cam</name>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
   <description>A ROS Driver for V4L USB Cameras</description>
 
   <maintainer email="rctoris@wpi.edu">Russell Toris</maintainer>


### PR DESCRIPTION
Backmerge finalized release 1.1.2 into develop.