### PR TITLE
F3-14297: PoE camera interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .cproject
 .project
 .settings
+nodes/src.code-workspace

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ pkg_check_modules(avcodec libavcodec REQUIRED)
 pkg_check_modules(swscale libswscale REQUIRED)
 pkg_check_modules(udev libudev REQUIRED)
 
+## Find OpenCV for video_stream_opencv and poe_cam support
+find_package(OpenCV REQUIRED)
+
 ###################################################
 ## Declare things to be passed to other projects ##
 ###################################################
@@ -38,18 +41,21 @@ include_directories(include
   ${catkin_INCLUDE_DIRS}
   ${avcodec_INCLUDE_DIRS}
   ${swscale_INCLUDE_DIRS}
+  ${OpenCV_INCLUDE_DIRS}
 )
 
 ## Build the USB camera library
 add_library(${PROJECT_NAME}
   src/device_utils.cpp
   src/usb_cam.cpp
+  src/poe_cam.cpp
 )
 
 target_link_libraries(${PROJECT_NAME}
   ${avcodec_LIBRARIES}
   ${swscale_LIBRARIES}
   ${catkin_LIBRARIES}
+  ${OpenCV_LIBRARIES}
   ${GCC_COVERAGE_LINK_FLAGS}
 )
 
@@ -61,6 +67,17 @@ target_link_libraries(${PROJECT_NAME}_node
   ${swscale_LIBRARIES}
   ${catkin_LIBRARIES}
   ${udev_LIBRARIES}
+  ${OpenCV_LIBRARIES}
+)
+
+add_executable(poe_cam_node nodes/poe_cam_node.cpp)
+target_link_libraries(poe_cam_node
+  ${PROJECT_NAME}
+  ${avcodec_LIBRARIES}
+  ${swscale_LIBRARIES}
+  ${catkin_LIBRARIES}
+  ${udev_LIBRARIES}
+  ${OpenCV_LIBRARIES}
 )
 
 #############
@@ -69,6 +86,7 @@ target_link_libraries(${PROJECT_NAME}_node
 
 ## Mark executables and/or libraries for installation
 install(TARGETS ${PROJECT_NAME}_node ${PROJECT_NAME}
+  poe_cam_node
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 )

--- a/include/usb_cam/poe_cam.h
+++ b/include/usb_cam/poe_cam.h
@@ -97,7 +97,7 @@ class PoECam {
   bool grab_image();
   bool open_camera();
   bool reopen_camera();
-  void convert_frame_to_image();
+  // void convert_frame_to_image();  // unused
 
   std::string camera_url_;
   std::unique_ptr<cv::VideoCapture> video_capture_;

--- a/include/usb_cam/poe_cam.h
+++ b/include/usb_cam/poe_cam.h
@@ -1,0 +1,117 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, Robert Bosch LLC.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Robert Bosch nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************/
+#ifndef USB_CAM_POE_CAM_H
+#define USB_CAM_POE_CAM_H
+
+#include <opencv2/opencv.hpp>
+#include <string>
+#include <memory>
+#include <sensor_msgs/Image.h>
+
+namespace usb_cam {
+
+class PoECam {
+ public:
+  typedef enum
+  {
+    PIXEL_FORMAT_YUYV, PIXEL_FORMAT_UYVY, PIXEL_FORMAT_MJPEG, PIXEL_FORMAT_YUVMONO10, 
+    PIXEL_FORMAT_RGB24, PIXEL_FORMAT_GREY, PIXEL_FORMAT_UNKNOWN
+  } pixel_format;
+
+  PoECam();
+  ~PoECam();
+
+  // start camera (camera_url can be URL or IP address for PoE cameras)
+  bool start(const std::string& camera_url, pixel_format pf);
+  
+  // shutdown camera
+  void shutdown(void);
+
+  // grabs a new image from the camera
+  bool grab_image(sensor_msgs::Image* image);
+
+  // enables/disable auto focus
+  void set_auto_focus(int value);
+
+  static bool device_supports_pixel_format(const std::string& device, const std::string& pixel_format);
+
+  //static io_method io_method_from_string(const std::string& str);
+  static pixel_format pixel_format_from_string(const std::string& str);
+
+  void stop_capturing(void);
+  void start_capturing(void);
+  bool is_capturing();
+
+  bool is_changing_config();
+  void is_changing_config(bool is_changing);
+
+  int Width() const{ return camera_width_; }
+  int Height() const{ return camera_height_; }
+  int FPS() const{ return framerate_; }
+
+ private:
+  typedef struct
+  {
+    int width;
+    int height;
+    int bytes_per_pixel;
+    int image_size;
+    char *image;
+    int is_new;
+  } camera_image_t;
+
+  void process_image(const cv::Mat& frame);
+  bool grab_image();
+  bool open_camera();
+  bool reopen_camera();
+  void convert_frame_to_image();
+
+  std::string camera_url_;
+  std::unique_ptr<cv::VideoCapture> video_capture_;
+  std::unique_ptr<camera_image_t> image_;
+  cv::Mat current_frame_;
+  bool is_capturing_;
+  bool is_changing_config_;
+  bool monochrome_;
+  int pixel_format_;
+  int framerate_;
+  int camera_width_;
+  int camera_height_;
+};
+
+}
+
+#endif

--- a/launch/poe_cam-test.launch
+++ b/launch/poe_cam-test.launch
@@ -15,7 +15,7 @@
     <param name="camera_frame_id" value="poe_cam3" />
   </node>
 
-  <!-- Streams all image topics over HTTP. Open http://localhost:8180 in a browser. -->
+  <!-- Streams all image topics over HTTP. Open http://localhost:8080 in a browser. -->
   <node name="web_video_server" pkg="web_video_server" type="web_video_server" output="screen">
     <param name="port" value="8080"/>
   </node>

--- a/launch/poe_cam-test.launch
+++ b/launch/poe_cam-test.launch
@@ -1,20 +1,24 @@
 <launch>
   <node name="poe_cam1" pkg="usb_cam" type="poe_cam_node" output="screen" >
-    <param name="video_url" value="rtsp://192.168.1.168:554/stream" />
+    <param name="video_url" value="rtsp://192.168.41.61:553/stream" />
     <param name="pixel_format" value="rgb24" />
     <param name="camera_frame_id" value="poe_cam1" />
   </node>
   <node name="poe_cam2" pkg="usb_cam" type="poe_cam_node" output="screen" >
-    <param name="video_url" value="rtsp://192.168.1.169:554/stream" />
+    <param name="video_url" value="rtsp://192.168.41.63:553/stream" />
     <param name="pixel_format" value="rgb24" />
     <param name="camera_frame_id" value="poe_cam2" />
   </node>
   <node name="poe_cam3" pkg="usb_cam" type="poe_cam_node" output="screen" >
-    <param name="video_url" value="rtsp://192.168.1.170:554/stream" />
+    <param name="video_url" value="rtsp://192.168.41.62:553/stream" />
     <param name="pixel_format" value="rgb24" />
     <param name="camera_frame_id" value="poe_cam3" />
   </node>
 
+  <!-- Streams all image topics over HTTP. Open http://localhost:8180 in a browser. -->
+  <node name="web_video_server" pkg="web_video_server" type="web_video_server" output="screen">
+    <param name="port" value="8080"/>
+  </node>
   <!-- The image_view nodes are for debugging only-->
   <!--
   <node name="image_view1" pkg="image_view" type="image_view" respawn="false" output="screen">

--- a/launch/poe_cam-test.launch
+++ b/launch/poe_cam-test.launch
@@ -1,0 +1,37 @@
+<launch>
+  <node name="poe_cam1" pkg="usb_cam" type="poe_cam_node" output="screen" >
+    <param name="video_url" value="rtsp://192.168.1.168:554/stream" />
+    <param name="pixel_format" value="rgb24" />
+    <param name="camera_frame_id" value="poe_cam1" />
+  </node>
+  <node name="poe_cam2" pkg="usb_cam" type="poe_cam_node" output="screen" >
+    <param name="video_url" value="rtsp://192.168.1.169:554/stream" />
+    <param name="pixel_format" value="rgb24" />
+    <param name="camera_frame_id" value="poe_cam2" />
+  </node>
+  <node name="poe_cam3" pkg="usb_cam" type="poe_cam_node" output="screen" >
+    <param name="video_url" value="rtsp://192.168.1.170:554/stream" />
+    <param name="pixel_format" value="rgb24" />
+    <param name="camera_frame_id" value="poe_cam3" />
+  </node>
+
+  <!-- The image_view nodes are for debugging only-->
+  <!--
+  <node name="image_view1" pkg="image_view" type="image_view" respawn="false" output="screen">
+    <remap from="image" to="/poe_cam1/image_raw"/>
+    <param name="autosize" value="true" />
+  </node>
+  -->
+  <!--
+  <node name="image_view2" pkg="image_view" type="image_view" respawn="false" output="screen">
+    <remap from="image" to="/poe_cam2/image_raw"/>
+    <param name="autosize" value="true" />
+  </node>
+  -->
+  <!--
+  <node name="image_view3" pkg="image_view" type="image_view" respawn="false" output="screen">
+    <remap from="image" to="/poe_cam3/image_raw"/>
+    <param name="autosize" value="true" />
+  </node>
+  -->
+</launch>

--- a/nodes/poe_cam_node.cpp
+++ b/nodes/poe_cam_node.cpp
@@ -24,7 +24,7 @@ namespace usb_cam {
 
 namespace
 {
-std::string resolve_device_path(const std::string& p)
+[[maybe_unused]] std::string resolve_device_path(const std::string& p)
 {
   try
   {

--- a/nodes/poe_cam_node.cpp
+++ b/nodes/poe_cam_node.cpp
@@ -1,0 +1,176 @@
+/*********************************************************************
+ *
+ * PoE camera node: mirrors usb_cam_node but uses rtsp protocol and OpenCV's 
+ * VideoCapture instead of V4L2 to capture images from PoE cameras. This 
+ * allows support for a wider range of cameras, including those that do not 
+ * have Linux drivers.
+ *
+ *********************************************************************/
+#include <filesystem>
+
+#include <ros/ros.h>
+#include <usb_cam/poe_cam.h>
+#include <image_transport/image_transport.h>
+#include <camera_info_manager/camera_info_manager.h>
+#include <memory>
+#include <sstream>
+#include <vector>
+#include <std_srvs/Empty.h>
+#include <std_srvs/SetBool.h>
+#include <thread>
+#include <misocpp/diagnostic_updater_wrapper.h>
+
+namespace usb_cam {
+
+namespace
+{
+std::string resolve_device_path(const std::string& p)
+{
+  try
+  {
+    return std::filesystem::weakly_canonical(p).string();
+  }
+  catch (const std::exception&)
+  {
+    return p;
+  }
+}
+}  // namespace
+
+class PoECamNode
+{
+  misocpp::DiagnosticHeartbeat heartbeat_;
+  std::unique_ptr<misocpp::DiagnosticFrequency> diag_freq_image_raw_{ nullptr };
+  std::unique_ptr<misocpp::DiagnosticFrequency> diag_freq_camera_info_{ nullptr };
+  double expected_freq_;
+
+public:
+  ros::NodeHandle node_;
+  sensor_msgs::Image img_;
+  image_transport::CameraPublisher image_pub_;
+
+  std::string camera_url_, camera_name_, camera_info_url_;
+  int framerate_;
+  std::string io_method_name_, pixel_format_name_;
+
+  boost::shared_ptr<camera_info_manager::CameraInfoManager> cinfo_;
+
+  PoECam cam_;
+
+  ros::ServiceServer service_start_, service_stop_, service_auto_reset_exposure_, reset_exposure_;
+
+  PoECamNode() : node_("~")
+  {
+    image_transport::ImageTransport it(node_);
+    image_pub_ = it.advertiseCamera("image_raw", 1);
+
+    node_.param("video_url", camera_url_, std::string("rtsp://127.0.0.1:554/stream"));
+    node_.param("pixel_format", pixel_format_name_, std::string("rgb24"));
+
+    node_.param("camera_frame_id", img_.header.frame_id, std::string("poe_camera"));
+    node_.param("camera_name", camera_name_, std::string("poe_camera"));
+    node_.param("camera_info_url", camera_info_url_, std::string(""));
+
+    cinfo_.reset(new camera_info_manager::CameraInfoManager(node_, camera_name_, camera_info_url_));
+
+    // start camera using PoECam API
+    PoECam::pixel_format pf = PoECam::pixel_format_from_string(pixel_format_name_);
+
+    if (!cam_.start(camera_url_, pf)) {
+      ROS_ERROR("PoE camera failed to start: %s", camera_url_.c_str());
+    }
+
+    framerate_ = cam_.FPS();
+    if (framerate_ <= 0) {
+      framerate_ = 30;
+      ROS_WARN("Invalid camera frame rate reported, defaulting to %d Hz", framerate_);
+    }
+
+    if (!cinfo_->isCalibrated())
+    {
+      cinfo_->setCameraName(camera_url_);
+      sensor_msgs::CameraInfo camera_info;
+      camera_info.header.frame_id = img_.header.frame_id;
+      camera_info.width = cam_.Width();
+      camera_info.height = cam_.Height();
+      cinfo_->setCameraInfo(camera_info);
+    }
+
+    expected_freq_ = static_cast<double>(framerate_);
+    std::filesystem::path topic = ros::this_node::getNamespace();
+    topic /= image_pub_.getTopic();
+    diag_freq_image_raw_ = std::make_unique<misocpp::DiagnosticFrequency>(topic.c_str(), expected_freq_, expected_freq_);
+
+    std::string s(topic);
+    s = s.erase(s.rfind('/'), std::string::npos);
+    topic = s;
+    topic /= "camera_info";
+    diag_freq_camera_info_ = std::make_unique<misocpp::DiagnosticFrequency>(topic.c_str(), expected_freq_, expected_freq_);
+
+    // services
+    service_start_ = node_.advertiseService("start_capture", &PoECamNode::service_start_cap, this);
+    service_stop_ = node_.advertiseService("stop_capture", &PoECamNode::service_stop_cap, this);
+  }
+
+  virtual ~PoECamNode()
+  {
+    cam_.shutdown();
+  }
+
+  bool service_start_cap(std_srvs::Empty::Request&, std_srvs::Empty::Response&)
+  {
+    cam_.start_capturing();
+    return true;
+  }
+
+  bool service_stop_cap(std_srvs::Empty::Request&, std_srvs::Empty::Response&)
+  {
+    cam_.stop_capturing();
+    return true;
+  }
+
+  bool take_and_send_image()
+  {
+    if (!cam_.grab_image(&img_))
+    {
+      ROS_WARN_THROTTLE(5.0, "PoE camera did not respond, will retry.");
+      return false;
+    }
+
+    sensor_msgs::CameraInfoPtr ci(new sensor_msgs::CameraInfo(cinfo_->getCameraInfo()));
+    ci->header.frame_id = img_.header.frame_id;
+    ci->header.stamp = img_.header.stamp;
+
+    image_pub_.publish(img_, *ci);
+    diag_freq_camera_info_->tick();
+    diag_freq_image_raw_->tick();
+    return true;
+  }
+
+  bool spin()
+  {
+    ros::Rate loop_rate(this->framerate_);
+    while (node_.ok())
+    {
+      if (cam_.is_capturing() && !cam_.is_changing_config())
+      {
+        if (!take_and_send_image()) ROS_WARN("PoE camera did not respond in time.");
+      }
+      heartbeat_.update();
+      loop_rate.sleep();
+    }
+    return true;
+  }
+};
+
+}  // namespace usb_cam
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "poe_cam");
+  ros::AsyncSpinner spinner{2};
+  spinner.start();
+  usb_cam::PoECamNode n;
+  n.spin();
+  return EXIT_SUCCESS;
+}

--- a/package.xml
+++ b/package.xml
@@ -30,7 +30,7 @@
   <build_depend>camera_info_manager</build_depend>
   <build_depend>diagnostic_updater</build_depend>
   <build_depend>video_stream_opencv</build_depend>
-  <build_depend>cv-bridge</build_depend>
+  <build_depend>cv_bridge</build_depend>
   <build_depend>opencv</build_depend>
 
   <exec_depend>image_transport</exec_depend>
@@ -44,6 +44,6 @@
   <exec_depend>v4l-utils</exec_depend>
   <exec_depend>diagnostic_updater</exec_depend>
   <exec_depend>video_stream_opencv</exec_depend>
-  <exec_depend>cv-bridge</exec_depend>
+  <exec_depend>cv_bridge</exec_depend>
   <exec_depend>opencv</exec_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -29,6 +29,9 @@
   <build_depend>ffmpeg</build_depend>
   <build_depend>camera_info_manager</build_depend>
   <build_depend>diagnostic_updater</build_depend>
+  <build_depend>video_stream_opencv</build_depend>
+  <build_depend>cv-bridge</build_depend>
+  <build_depend>opencv</build_depend>
 
   <exec_depend>image_transport</exec_depend>
   <exec_depend>roscpp</exec_depend>
@@ -40,4 +43,7 @@
   <exec_depend>camera_info_manager</exec_depend>
   <exec_depend>v4l-utils</exec_depend>
   <exec_depend>diagnostic_updater</exec_depend>
+  <exec_depend>video_stream_opencv</exec_depend>
+  <exec_depend>cv-bridge</exec_depend>
+  <exec_depend>opencv</exec_depend>
 </package>

--- a/scripts/detect_and_cut_frozen_stream.py
+++ b/scripts/detect_and_cut_frozen_stream.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+import sys
+import os
+import argparse
+import csv
+import time
+import numpy as np
+import cv2
+import rosbag
+import rospy
+from cv_bridge import CvBridge, CvBridgeError
+
+# --- CONFIGURATION FOR STREAM DETECTION ---
+VIDEO_TOPICS = [
+    "/poe_cam1/image_raw/compressed",
+    "/poe_cam2/image_raw/compressed",
+    "/poe_cam3/image_raw/compressed"
+]
+
+MSE_THRESHOLD = 150
+MAX_FRAME_GAP = 1.0  # Time gap threshold in seconds to count as a frozen skip
+NON_FROZEN_BUFFER = 0.5  # Extra seconds of padding to preserve on healthy segments
+
+OUTPUT_FILENAME = "frozen_intervals.txt"
+MSE_CSV_FILENAME = "mse_over_time.csv"
+# -----------------------------------------
+
+def calculate_mse(imageA, imageB):
+    """Calculate the Mean Squared Error between two images."""
+    if imageA.shape != imageB.shape:
+        return float('inf')
+    err = np.sum((imageA.astype("float") - imageB.astype("float")) ** 2)
+    err /= float(imageA.shape[0] * imageA.shape[1] * (imageA.shape[2] if len(imageA.shape) > 2 else 1))
+    return err
+
+def consolidate_intervals(intervals):
+    """Merges overlapping or adjacent time intervals."""
+    if not intervals:
+        return []
+    sorted_inv = sorted(intervals, key=lambda x: x[0])
+    merged = [sorted_inv[0]]
+    for current in sorted_inv[1:]:
+        prev_start, prev_end = merged[-1]
+        curr_start, curr_end = current
+        if curr_start <= prev_end:
+            merged[-1] = (prev_start, max(prev_end, curr_end))
+        else:
+            merged.append(current)
+    return merged
+
+def calculate_remaining_intervals(bag_start, bag_end, banned_intervals):
+    """Calculates the surviving time segments based on the full bag limits."""
+    if not banned_intervals:
+        return [(bag_start, bag_end)]
+    remaining = []
+    current_track = bag_start
+    for ban_start, ban_end in banned_intervals:
+        if ban_start >= bag_end:
+            break
+        if ban_end <= bag_start:
+            continue
+        actual_ban_start = max(bag_start, ban_start)
+        actual_ban_end = min(bag_end, ban_end)
+        if current_track < actual_ban_start:
+            remaining.append((current_track, actual_ban_start))
+        current_track = max(current_track, actual_ban_end)
+    if current_track < bag_end:
+        remaining.append((current_track, bag_end))
+    return remaining
+
+def analyze_bag(bag_path):
+    """Analyzes the video topics sequentially for frozen intervals or long frame skips."""
+    bridge = CvBridge()
+    
+    topic_states = {
+        topic: {'last_cv_img': None, 'last_stamp': None, 'freeze_start_time': None, 'is_frozen': False} 
+        for topic in VIDEO_TOPICS
+    }
+    
+    frozen_intervals = []
+    mse_range = np.array([])
+    print(f"\nAnalyzing bag for frozen feeds (Sequential Safe Mode): {bag_path}")
+    start_processing_time = time.time()
+    
+    try:
+        with rosbag.Bag(bag_path, 'r') as bag, open(MSE_CSV_FILENAME, mode='w', newline='') as csv_file:
+            csv_writer = csv.writer(csv_file)
+            csv_writer.writerow(["Timestamp", "Topic", "MSE", "FrameGap"])
+            
+            info = bag.get_type_and_topic_info()
+            total_frames = sum(info.topics[t].message_count for t in VIDEO_TOPICS if t in info.topics)
+            
+            if total_frames == 0:
+                print("Error: None of the specified topics found or they contain 0 frames.")
+                return []
+                
+            print(f"Total video frames to process: {total_frames}")
+            current_frame = 0
+            current_time = None
+            
+            for topic, msg, t in bag.read_messages(topics=VIDEO_TOPICS):
+                current_frame += 1
+                percent = (current_frame / total_frames) * 100
+                
+                try:
+                    if hasattr(msg, 'format'):
+                        cv_img = bridge.compressed_imgmsg_to_cv2(msg, desired_encoding="passthrough")
+                    else:
+                        cv_img = bridge.imgmsg_to_cv2(msg, desired_encoding="passthrough")
+                except CvBridgeError as e:
+                    print(f"\nCvBridge Error on topic {topic}: {e}")
+                    continue
+
+                state = topic_states[topic]
+                current_time = msg.header.stamp 
+
+                if state['last_cv_img'] is None:
+                    state['last_cv_img'] = cv_img
+                    state['last_stamp'] = current_time
+                    continue
+
+                # Gap / Skip Detection
+                time_gap = (current_time - state['last_stamp']).to_sec()
+                is_skipped = time_gap > MAX_FRAME_GAP
+
+                # Visual Staleness Detection via MSE
+                MSE = calculate_mse(state['last_cv_img'], cv_img)
+                mse_range = np.append(mse_range, MSE)
+                csv_writer.writerow([f"{current_time.to_sec():.6f}", topic, f"{MSE:.4f}", f"{time_gap:.4f}"])
+                
+                sys.stdout.write(f"\rProcessing: [{current_frame}/{total_frames}] {percent:.1f}% Complete | MSE: {MSE:.2f} | Gap: {time_gap:.2f}s")
+                sys.stdout.flush()
+                is_static = MSE < MSE_THRESHOLD
+
+                # State machine tracking
+                if is_static or is_skipped:
+                    if not state['is_frozen']:
+                        state['freeze_start_time'] = state['last_stamp'] if is_skipped else current_time
+                        state['is_frozen'] = True
+                else:
+                    if state['is_frozen']:
+                        frozen_intervals.append((topic, state['freeze_start_time'].to_sec(), current_time.to_sec()))
+                        state['is_frozen'] = False
+                        state['freeze_start_time'] = None
+
+                state['last_cv_img'] = cv_img
+                state['last_stamp'] = current_time
+
+            for topic, state in topic_states.items():
+                if state['is_frozen'] and state['freeze_start_time'] is not None and current_time is not None:
+                    frozen_intervals.append((topic, state['freeze_start_time'].to_sec(), current_time.to_sec()))
+
+    except Exception as e:
+        print(f"\nError reading bag file during analysis: {e}")
+        return []
+
+    end_processing_time = time.time()
+    elapsed_time = end_processing_time - start_processing_time
+    print() 
+
+    # --- PRINT RESULTS ---
+    print("\n" + "="*60)
+    print("FROZEN / SKIPPED FEED DETECTION REPORT")
+    print(f"Bag Analysis Pass Execution Time: {elapsed_time:.2f} seconds")
+    
+    if mse_range.size > 0:
+        print(f" MSE Metrics: min:{np.min(mse_range):.4f}, max:{np.max(mse_range):.4f}, avg:{np.mean(mse_range):.4f}, std:{np.std(mse_range):.4f}")
+        print(f"[✔] Dataset with time gaps saved to: {MSE_CSV_FILENAME}")
+    print("="*60)
+    
+    pure_timestamps = []
+    if not frozen_intervals:
+        print("Success! No frozen feeds or time skips detected across topics.")
+    else:
+        print(f"Detected {len(frozen_intervals)} raw event instance(s):\n")
+        
+        total_raw_frozen_duration = 0.0
+        for topic, start, end in frozen_intervals:
+            duration = end - start
+            total_raw_frozen_duration += duration
+            pure_timestamps.append((start, end))
+            
+            print(f" [!] Topic: {topic}")
+            print(f"     Start Timestamp : {start:.4f}")
+            print(f"     End Timestamp   : {end:.4f}")
+            print(f"     Total Duration  : {duration:.2f} seconds")
+            print("-" * 50)
+            
+        consolidated = consolidate_intervals(pure_timestamps)
+        unique_frozen_duration = sum((end - start) for start, end in consolidated)
+        
+        print("\n" + "="*60)
+        print("CUMULATIVE TIME ANALYSIS")
+        print("="*60)
+        print(f" Sum of all frozen intervals (Raw total) : {total_raw_frozen_duration:.2f} seconds")
+        print(f" Unique timeline time frozen (Merged)    : {unique_frozen_duration:.2f} seconds")
+        print("="*60)
+        
+        try:
+            with open(OUTPUT_FILENAME, "w") as f:
+                for start, end in pure_timestamps:
+                    f.write(f"{start:.6f},{end:.6f}\n")
+            print(f"[✔] Successfully saved raw intervals to text file: {OUTPUT_FILENAME}")
+        except IOError as e:
+            print(f"[❌] Error writing to file {OUTPUT_FILENAME}: {e}")
+
+    return pure_timestamps
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Detect frozen video streams in a ROS bag and cut those segments out while protecting non-frozen footage boundaries."
+    )
+    parser.add_argument('-i', '--input', required=True, help="Path to input .bag file")
+    parser.add_argument('-o', '--output', required=True, help="Path to save output modified .bag file")
+
+    args = parser.parse_args()
+
+    if not os.path.exists(args.input):
+        print(f"Error: The input bag file '{args.input}' does not exist.")
+        sys.exit(1)
+
+    # Start overall operation timer
+    script_start_time = time.time()
+
+    print(f"Scanning input bag metadata: {args.input}")
+    try:
+        in_bag = rosbag.Bag(args.input)
+        bag_start = in_bag.get_start_time()
+        bag_end = in_bag.get_end_time()
+    except Exception as e:
+        print(f"Error reading bag metadata: {e}")
+        sys.exit(1)
+
+    print(f"  Original Bag Range: {bag_start:.4f} to {bag_end:.4f} ({bag_end - bag_start:.2f} seconds)")
+
+    raw_cuts = analyze_bag(args.input)
+    banned_sections = consolidate_intervals(raw_cuts)
+
+    # Apply safety padding to preserve healthy footage
+    # We shift the cut boundaries inward, effectively expanding the healthy non-frozen window.
+    valid_banned_sections = []
+    for s, e in banned_sections:
+        padded_start = s + NON_FROZEN_BUFFER
+        padded_end = e - NON_FROZEN_BUFFER
+        
+        # If the frozen window was smaller than the total buffer size, it gets completely eliminated
+        if padded_start >= padded_end:
+            continue
+            
+        if padded_end <= bag_start or padded_start >= bag_end:
+            continue
+            
+        valid_banned_sections.append((max(bag_start, padded_start), min(bag_end, padded_end)))
+
+    remaining_intervals = calculate_remaining_intervals(bag_start, bag_end, valid_banned_sections)
+
+    print("\n================ TIMELINE EXCISAL ANALYSIS ================")
+    print(f"Loaded {len(raw_cuts)} raw events -> Adjusted to preserve extra {NON_FROZEN_BUFFER}s of healthy frames.")
+    print(f"Resulted in {len(valid_banned_sections)} distinct cutting blocks.")
+    print("\n[The following global intervals will be kept and shifted]:")
+    for idx, (s, e) in enumerate(remaining_intervals, 1):
+        print(f"  Interval #{idx}: {s:.4f} --> {e:.4f} ({e - s:.2f}s)")
+    print("===========================================================\n")
+
+    messages_written = 0
+    print("Processing and recalculating timestamps...")
+    
+    try:
+        with rosbag.Bag(args.output, 'w') as outbag:
+            accumulated_shift = 0.0
+            last_processed_edge = bag_start
+
+            for idx, (start_f, end_f) in enumerate(remaining_intervals, 1):
+                gap = start_f - last_processed_edge
+                accumulated_shift += gap
+                
+                print(f"  Writing Interval #{idx}/{len(remaining_intervals)} (Shifted forward by -{accumulated_shift:.2f}s)...")
+                
+                start_time = rospy.Time.from_sec(start_f)
+                end_time = rospy.Time.from_sec(end_f)
+                
+                for topic, msg, t in in_bag.read_messages(start_time=start_time, end_time=end_time):
+                    new_epoch = t.to_sec() - accumulated_shift
+                    new_ros_time = rospy.Time.from_sec(new_epoch)
+                    
+                    if hasattr(msg, 'header') and hasattr(msg.header, 'stamp'):
+                        msg_epoch = msg.header.stamp.to_sec() - accumulated_shift
+                        msg.header.stamp = rospy.Time.from_sec(msg_epoch)
+                    
+                    outbag.write(topic, msg, new_ros_time)
+                    messages_written += 1
+                
+                last_processed_edge = end_f
+
+        print("---------------------------------------------------")
+        print(f"Success! Output saved to: {args.output}")
+        print(f"Total Messages Saved: {messages_written}")
+        
+        if messages_written > 0:
+            out_bag_check = rosbag.Bag(args.output)
+            new_duration = out_bag_check.get_end_time() - out_bag_check.get_start_time()
+            print(f"New Compressed Bag Duration: {new_duration:.2f} seconds.")
+            out_bag_check.close()
+
+    except Exception as e:
+        print(f"An error occurred during filtering: {e}")
+    finally:
+        in_bag.close()
+
+    # Calculate and output total benchmark time
+    script_total_time = time.time() - script_start_time
+    print("\n" + "░"*60)
+    print(f" TOTAL OPERATION COMPUTATION TIME: {script_total_time:.2f} seconds")
+    print("░"*60 + "\n")
+
+if __name__ == '__main__':
+    main()

--- a/scripts/record_basket_data.sh
+++ b/scripts/record_basket_data.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+
+# Configuration
+RECORD_DURATION=3         # Duration to record in seconds per iteration
+BAG_DIR="/root/workspace/saved_data/bag_data"  # Directory to save bag files
+
+# Array of all robot operations
+robot_cmds=(
+	"test_behavior move fryer_inspection auto_basket_interface False"
+	"test_behavior interface_pickup 3 False"
+
+	# start operations for fryer 1
+	"test_behavior move auto_basket_interface canal_interface_slot_1 True"
+	"test_behavior hanger_dropoff 1"
+
+	# move robot out of the way
+	# take snapshots
+	# move robot back
+	"echo 1"
+	
+	# place it in the fryer
+	"test_behavior hanger_pickup 1"
+	"test_behavior submerge 1 3"
+	
+	# move robot out of the way
+	# take snapshots
+	# move robot back
+	"echo 1"
+	
+	# take it out of the fryer
+	"test_behavior unsubmerge 1 3 4"
+	
+	# start operation for fryer 2
+	"test_behavior move canal_interface_slot_1 canal_interface_slot_2 True"
+	"test_behavior hanger_dropoff 2"
+	
+	# move robot out of the way
+	# take snapshots
+	# move robot back
+	"echo 2"
+	
+	"test_behavior hanger_pickup 2"
+	"test_behavior submerge 2 3"
+	
+	# move robot out of the way
+	# take snapshots
+	# move robot back
+	"echo 2"
+	
+	"test_behavior unsubmerge 2 3 4"
+
+	# start operation for fryer 3
+	"test_behavior move canal_interface_slot_2 canal_interface_slot_3 True"
+	"test_behavior hanger_dropoff 3"
+	
+	# move robot out of the way
+	# take snapshots
+	# move robot back
+	"echo 3"
+	
+	"test_behavior hanger_pickup 3"
+	"test_behavior submerge 3 3"
+	
+	# move robot out of the way
+	# take snapshots
+	# move robot back
+	"echo 3"
+	
+	"test_behavior unsubmerge 3 3 4"
+
+	# start operation for fryer 4
+	"test_behavior move canal_interface_slot_3 canal_interface_slot_4 True"
+	"test_behavior hanger_dropoff 4"
+	
+	# move robot out of the way
+	# take snapshots
+	# move robot back
+	"echo 4"
+	
+	"test_behavior hanger_pickup 4"
+	"test_behavior submerge 4 3"
+	
+	# move robot out of the way
+	# take snapshots
+	# move robot back
+	"echo 4"
+	
+	"test_behavior unsubmerge 4 3 4"
+
+	# start operation for fryer 5
+	"test_behavior move canal_interface_slot_4 canal_interface_slot_5 True"
+	"test_behavior hanger_dropoff 5"
+	
+	# move robot out of the way
+	# take snapshots
+	# move robot back
+	"echo 5"
+	
+	"test_behavior hanger_pickup 5"
+	"test_behavior submerge 5 3"
+	
+	# move robot out of the way
+	# take snapshots
+	# move robot back
+	"echo 5"
+	
+	"test_behavior unsubmerge 5 3 4"
+
+	# start operation for fryer 6
+	"test_behavior move canal_interface_slot_5 canal_interface_slot_6 True"
+	"test_behavior hanger_dropoff 6"
+	
+	# move robot out of the way
+	# take snapshots
+	# move robot back
+	"echo 6"
+	
+	"test_behavior hanger_pickup 6"
+	"test_behavior submerge 6 3"
+	
+	# move robot out of the way
+	# take snapshots
+	# move robot back
+	"echo 6"
+	
+	"test_behavior unsubmerge 6 3 4"
+	
+	# place basket back to origin
+	"test_behavior move canal_interface_slot_6 auto_basket_interface True"
+	"test_behavior interface_dropoff 3"
+)
+
+# Create bag directory if it doesn't exist
+mkdir -p "$BAG_DIR"
+
+echo "========================================="
+echo "Starting Data Collection for ML/Vision"
+echo "========================================="
+
+rosservice call /go_to_named_joints "named_joints: 'fryer_inspection'"
+
+# Loop through the indices using the '!' operator
+for robot_cmd in "${robot_cmds[@]}"; do
+
+    # Run step 1 for robot
+    echo "** Running command **: $robot_cmd"
+    eval "$robot_cmd"
+
+	if [[ "${robot_cmd}" =~ ^echo\ ([0-9]+)$ ]]; then
+		# allow for a slight lag in capture stream
+		# sleep 1.0
+
+		# Extract the integer from the regex capture group
+    	EXTRACTED_INT="${BASH_REMATCH[1]}"
+		
+		echo "Going from fryer $EXTRACTED_INT to fryer inspection"
+		eval "test_behavior move canal_interface_slot_$EXTRACTED_INT fryer_inspection False"
+		
+		# Start rosbag recording
+		echo "** Recording rosbag **: ${BAG_DIR}/${TODAY}_camera_data_%05i.bag"
+		rosbag record --duration=$RECORD_DURATION /poe_cam1/image_raw/compressed /poe_cam2/image_raw/compressed /poe_cam3/image_raw/compressed -o "${BAG_DIR}/cam_data_.bag"
+		
+		echo "Going from fryer inspection to fryer $EXTRACTED_INT"
+		eval "test_behavior move fryer_inspection canal_interface_slot_$EXTRACTED_INT False"
+	fi
+
+done
+
+rosservice call /go_to_named_joints "named_joints: 'fryer_inspection'"
+
+echo "Data capture complete"

--- a/scripts/record_basket_data.sh
+++ b/scripts/record_basket_data.sh
@@ -3,6 +3,7 @@
 # Configuration
 RECORD_DURATION=3         # Duration to record in seconds per iteration
 BAG_DIR="/root/workspace/saved_data/bag_data"  # Directory to save bag files
+TODAY="$(date +%Y%m%d)"
 
 # Array of all robot operations
 robot_cmds=(

--- a/scripts/set_poe_cam_params.py
+++ b/scripts/set_poe_cam_params.py
@@ -1,0 +1,65 @@
+import asyncio
+import os
+import onvif
+from onvif import ONVIFCamera
+
+async def main():
+    wsdl_path = os.path.join(os.path.dirname(onvif.__file__), "wsdl")
+    
+    print("Connecting to camera at 192.168.41.63...")
+    mycam = ONVIFCamera('192.168.41.63', 80, 'admin', 'camera', wsdl_dir=wsdl_path)
+    
+    try:
+        await mycam.update_xaddrs()
+        media_service = await mycam.create_media_service()
+        
+        # Get the encoders
+        encoders = await media_service.GetVideoEncoderConfigurations()
+        if not encoders:
+            print("No video encoder configurations found.")
+            return
+            
+        target_encoder = encoders[0]
+        print(f"Modifying Encoder Token: '{target_encoder.token}'")
+
+        # --- MATCHING YOUR IMAGE SETTINGS (STRICT SCHEMA MODE) ---
+        
+        # 1. Encoding Codec (H.264)
+        target_encoder.Encoding = 'H264'
+
+        # 2. Resolution (4K UHD: 3840 x 2160)
+        target_encoder.Resolution.Width = 3840
+        target_encoder.Resolution.Height = 2160
+
+        # 3. Frame Rate (20 fps)
+        target_encoder.RateControl.FrameRateLimit = 20
+
+        # 4. Maximum Bit Rate (8000 kbps)
+        target_encoder.RateControl.BitrateLimit = 8000
+
+        # 5. GOP Size & Profile (Routed into the H264 sub-configuration block)
+        if hasattr(target_encoder, 'H264') and target_encoder.H264 is not None:
+            target_encoder.H264.GovLength = 20
+            target_encoder.H264.H264Profile = 'High'
+            
+        # 6. Delete top-level properties that caused previous schema validation errors
+        if hasattr(target_encoder, 'GovLength'):
+            delattr(target_encoder, 'GovLength')
+
+        # --- PUSH CHANGES TO CAMERA ---
+        print("\nApplying settings to match the image layout...")
+        await media_service.SetVideoEncoderConfiguration({
+            'Configuration': target_encoder, 
+            'ForcePersistence': True
+        })
+        print("Success! Settings applied and saved to persistent memory.")
+        
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        
+    finally:
+        print("Closing connection safely...")
+        await mycam.close()
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/scripts/set_poe_cam_params.py
+++ b/scripts/set_poe_cam_params.py
@@ -6,8 +6,15 @@ from onvif import ONVIFCamera
 async def main():
     wsdl_path = os.path.join(os.path.dirname(onvif.__file__), "wsdl")
     
-    print("Connecting to camera at 192.168.41.63...")
-    mycam = ONVIFCamera('192.168.41.63', 80, 'admin', 'camera', wsdl_dir=wsdl_path)
+    host = os.environ.get("POE_CAM_HOST", "192.168.41.63")
+    port = int(os.environ.get("POE_CAM_PORT", "80"))
+    user = os.environ.get("POE_CAM_USER", "admin")
+    password = os.environ.get("POE_CAM_PASSWORD")
+    if not password:
+        raise RuntimeError("POE_CAM_PASSWORD must be set")
+
+    print(f"Connecting to camera at {host}...")
+    mycam = ONVIFCamera(host, port, user, password, wsdl_dir=wsdl_path)
     
     try:
         await mycam.update_xaddrs()

--- a/src/poe_cam.cpp
+++ b/src/poe_cam.cpp
@@ -1,0 +1,314 @@
+/*********************************************************************
+ *
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, Robert Bosch LLC.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Robert Bosch nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ *********************************************************************/
+#include <opencv2/opencv.hpp>
+#include <ros/ros.h>
+#include <sensor_msgs/fill_image.h>
+#include <usb_cam/poe_cam.h>
+#include <vector>
+
+namespace usb_cam {
+
+PoECam::PoECam()
+  : is_capturing_(false), is_changing_config_(false), monochrome_(false),
+    pixel_format_(CV_8UC3), framerate_(30) {
+}
+
+PoECam::~PoECam() {
+  shutdown();
+}
+
+bool PoECam::start(const std::string& camera_url, pixel_format pf) {
+  camera_url_ = camera_url;
+
+  // Determine if monochrome based on pixel format
+  switch (pf) {
+    case PIXEL_FORMAT_YUVMONO10:
+    case PIXEL_FORMAT_GREY:
+      monochrome_ = true;
+      pixel_format_ = CV_8UC1;
+      break;
+    case PIXEL_FORMAT_RGB24:
+    case PIXEL_FORMAT_YUYV:
+    case PIXEL_FORMAT_UYVY:
+    case PIXEL_FORMAT_MJPEG:
+    default:
+      monochrome_ = false;
+      pixel_format_ = CV_8UC3;
+      break;
+  }
+
+  // Force FFMpeg to use TCP
+  setenv("OPENCV_FFMPEG_CAPTURE_OPTIONS", "rtsp_transport;tcp", 1);
+
+  // Initialize video capture with PoE camera
+  video_capture_ = std::make_unique<cv::VideoCapture>();
+  
+  // Try to open the camera
+  bool opened = false;
+
+  ROS_INFO("Opening camera with URL: %s", camera_url.c_str());
+  opened = video_capture_->open(camera_url, cv::CAP_FFMPEG);
+
+  if (!opened) {
+    ROS_ERROR("Failed to open camera: %s", camera_url.c_str());
+    return false;
+  }
+
+  // Set codec
+  video_capture_->set(cv::CAP_PROP_FOURCC, cv::VideoWriter::fourcc('h', 'v', 'c', '1'));
+
+  // Get camera properties from device
+  framerate_ = static_cast<int>(video_capture_->get(cv::CAP_PROP_FPS));
+  camera_width_ = static_cast<int>(video_capture_->get(cv::CAP_PROP_FRAME_WIDTH));
+  camera_height_ = static_cast<int>(video_capture_->get(cv::CAP_PROP_FRAME_HEIGHT));
+
+  ROS_INFO("Capture params: %d x %d : %d fps", camera_width_, camera_height_, framerate_);
+
+  // Allocate image buffer
+  image_ = std::make_unique<camera_image_t>();
+  image_->width = camera_width_;
+  image_->height = camera_height_;
+  image_->bytes_per_pixel = monochrome_ ? 1 : 3;
+  image_->image_size = image_->width * image_->height * image_->bytes_per_pixel;
+  image_->is_new = 0;
+  image_->image = (char *)calloc(image_->image_size, sizeof(char));
+  
+  if (!image_->image) {
+    ROS_ERROR("Failed to allocate image buffer");
+    return false;
+  }
+
+  memset(image_->image, 0, image_->image_size * sizeof(char));
+  
+  start_capturing();
+  return true;
+}
+
+bool PoECam::open_camera() {
+  if (camera_url_.empty()) {
+    ROS_ERROR("No camera URL configured for PoECam");
+    return false;
+  }
+
+  // Force FFMpeg to use TCP
+  setenv("OPENCV_FFMPEG_CAPTURE_OPTIONS", "rtsp_transport;tcp", 1);
+
+  video_capture_ = std::make_unique<cv::VideoCapture>();
+  ROS_INFO("Opening camera with URL: %s", camera_url_.c_str());
+
+  if (!video_capture_->open(camera_url_, cv::CAP_FFMPEG)) {
+    ROS_ERROR("Failed to open camera: %s", camera_url_.c_str());
+    return false;
+  }
+
+  video_capture_->set(cv::CAP_PROP_FOURCC, cv::VideoWriter::fourcc('h', 'v', 'c', '1'));
+  return true;
+}
+
+bool PoECam::reopen_camera() {
+  if (!video_capture_) {
+    return open_camera();
+  }
+
+  ROS_WARN("Reopening PoE camera stream: %s", camera_url_.c_str());
+  video_capture_->release();
+  return open_camera();
+}
+
+void PoECam::shutdown(void) {
+  stop_capturing();
+  
+  if (video_capture_ && video_capture_->isOpened()) {
+    video_capture_->release();
+  }
+  video_capture_.reset();
+
+  if (image_ && image_->image) {
+    free(image_->image);
+    image_->image = nullptr;
+  }
+  image_.reset();
+}
+
+bool PoECam::grab_image(sensor_msgs::Image* msg) {
+  if (!grab_image())
+    return false;
+
+  msg->header.stamp = ros::Time::now();
+  
+  if (monochrome_) {
+    fillImage(*msg, "mono8", image_->height, image_->width,
+              image_->width, image_->image);
+  } else {
+    fillImage(*msg, "rgb8", image_->height, image_->width,
+              3 * image_->width, image_->image);
+  }
+
+  return true;
+}
+
+bool PoECam::grab_image() {
+  if (!video_capture_ || !video_capture_->isOpened() || !is_capturing_) {
+    return false;
+  }
+
+  if (!video_capture_->read(current_frame_)) {
+    ROS_WARN("Failed to read frame from camera, attempting to reopen stream");
+    if (!reopen_camera()) {
+      ROS_ERROR("Failed to reopen camera stream");
+      return false;
+    }
+    if (!video_capture_->read(current_frame_)) {
+      ROS_ERROR("Failed to read frame from camera after reopen");
+      return false;
+    }
+  }
+
+  if (current_frame_.empty()) {
+    ROS_ERROR("Empty frame received");
+    return false;
+  }
+
+  process_image(current_frame_);
+  image_->is_new = 1;
+  return true;
+}
+
+void PoECam::process_image(const cv::Mat& frame) {
+  if (!image_ || !image_->image) {
+    return;
+  }
+
+  cv::Mat target_frame = frame.clone();
+
+  // Convert to appropriate format
+  if (monochrome_) {
+    if (target_frame.channels() != 1) {
+      cv::cvtColor(target_frame, target_frame, cv::COLOR_BGR2GRAY);
+    }
+  } else {
+    if (target_frame.channels() != 3) {
+      cv::cvtColor(target_frame, target_frame, cv::COLOR_YUV2BGR_I420);
+    }
+    // OpenCV uses BGR, but we need RGB for ROS
+    cv::cvtColor(target_frame, target_frame, cv::COLOR_BGR2RGB);
+  }
+
+  // Resize if needed
+  if (target_frame.rows != image_->height || target_frame.cols != image_->width) {
+    cv::resize(target_frame, target_frame, cv::Size(image_->width, image_->height));
+  }
+
+  // Copy frame data to image buffer
+  if (monochrome_) {
+    memcpy(image_->image, target_frame.data, image_->image_size);
+  } else {
+    // Ensure continuous memory layout
+    if (target_frame.isContinuous()) {
+      memcpy(image_->image, target_frame.data, image_->image_size);
+    } else {
+      char *dest = image_->image;
+      for (int i = 0; i < target_frame.rows; ++i) {
+        memcpy(dest, target_frame.ptr<uchar>(i), 
+               target_frame.cols * target_frame.channels());
+        dest += target_frame.cols * target_frame.channels();
+      }
+    }
+  }
+}
+
+void PoECam::set_auto_focus(int value) {
+  if (video_capture_ && video_capture_->isOpened()) {
+    video_capture_->set(cv::CAP_PROP_AUTOFOCUS, value);
+  }
+}
+
+bool PoECam::device_supports_pixel_format(const std::string& device, 
+                                          const std::string& pixel_format) {
+  // PoE cameras support most formats through video_stream_opencv
+  // This is a simplified check
+  return true;
+}
+
+PoECam::pixel_format PoECam::pixel_format_from_string(const std::string& str) {
+  if (str == "yuyv")
+    return PIXEL_FORMAT_YUYV;
+  else if (str == "uyvy")
+    return PIXEL_FORMAT_UYVY;
+  else if (str == "mjpeg")
+    return PIXEL_FORMAT_MJPEG;
+  else if (str == "yuvmono10")
+    return PIXEL_FORMAT_YUVMONO10;
+  else if (str == "rgb24")
+    return PIXEL_FORMAT_RGB24;
+  else if (str == "grey")
+    return PIXEL_FORMAT_GREY;
+  else
+    return PIXEL_FORMAT_UNKNOWN;
+}
+
+void PoECam::stop_capturing(void) {
+  if (!is_capturing_)
+    return;
+
+  is_capturing_ = false;
+  if (video_capture_ && video_capture_->isOpened()) {
+    video_capture_->release();
+  }
+}
+
+void PoECam::start_capturing(void) {
+  if (is_capturing_)
+    return;
+
+  if (video_capture_ && video_capture_->isOpened()) {
+    is_capturing_ = true;
+  }
+}
+
+bool PoECam::is_capturing() {
+  return is_capturing_;
+}
+
+bool PoECam::is_changing_config() {
+  return is_changing_config_;
+}
+
+void PoECam::is_changing_config(bool is_changing) {
+  is_changing_config_ = is_changing;
+}
+
+}  // namespace usb_cam

--- a/src/poe_cam.cpp
+++ b/src/poe_cam.cpp
@@ -87,9 +87,7 @@ bool PoECam::start(const std::string& camera_url, pixel_format pf) {
     return false;
   }
 
-  // Set codec
-  video_capture_->set(cv::CAP_PROP_FOURCC, cv::VideoWriter::fourcc('h', 'v', 'c', '1'));
-
+  // Keep the codec as provided by the RTSP source; forcing FOURCC here is often ignored or can break decoding.
   // Get camera properties from device
   framerate_ = static_cast<int>(video_capture_->get(cv::CAP_PROP_FPS));
   camera_width_ = static_cast<int>(video_capture_->get(cv::CAP_PROP_FRAME_WIDTH));
@@ -108,6 +106,8 @@ bool PoECam::start(const std::string& camera_url, pixel_format pf) {
   
   if (!image_->image) {
     ROS_ERROR("Failed to allocate image buffer");
+    video_capture_->release();
+    video_capture_.reset();
     return false;
   }
 
@@ -220,11 +220,17 @@ void PoECam::process_image(const cv::Mat& frame) {
       cv::cvtColor(target_frame, target_frame, cv::COLOR_BGR2GRAY);
     }
   } else {
-    if (target_frame.channels() != 3) {
-      cv::cvtColor(target_frame, target_frame, cv::COLOR_YUV2BGR_I420);
+    const int ch = target_frame.channels();
+    if (ch == 1) {
+      cv::cvtColor(target_frame, target_frame, cv::COLOR_GRAY2RGB);
+    } else if (ch == 3) {
+      cv::cvtColor(target_frame, target_frame, cv::COLOR_BGR2RGB);
+    } else if (ch == 4) {
+      cv::cvtColor(target_frame, target_frame, cv::COLOR_BGRA2RGB);
+    } else {
+      ROS_ERROR_THROTTLE(5.0, "Unsupported channel count from RTSP stream: %d", ch);
+      return;
     }
-    // OpenCV uses BGR, but we need RGB for ROS
-    cv::cvtColor(target_frame, target_frame, cv::COLOR_BGR2RGB);
   }
 
   // Resize if needed


### PR DESCRIPTION
This branch is adding a new class for capturing data using RTSP format on PoE cameras. It implements a camera class that can be called from a launch file similar to the usb_cam class. A poe_cam_test.launch file is provided to run your own PoE cameras and live stream on port 8080.

`roslaunch usb_cam poe_cam-test.launch`

Bash script is included to capture the images from the PoE cameras during test_behaviors on Flippy.

Python script is included to set the parameters of each camera using the `ONVIFCamera` interface.